### PR TITLE
docs(migraiton): add netlify footer badge

### DIFF
--- a/themes/docsy-master/layouts/partials/footer.html
+++ b/themes/docsy-master/layouts/partials/footer.html
@@ -25,6 +25,11 @@
       </div>
     </div>
   </div>
+  
+    <a href="https://www.netlify.com">
+      <img src="https://www.netlify.com/img/global/badges/netlify-dark.svg" alt="Deploys by Netlify" />
+    </a>
+  </div>
 </footer>
 {{ define "footer-links-block" }}
 <ul class="list-inline mb-0">


### PR DESCRIPTION
Adding the Netlify footer badge. We can change the color of the badge or swap to a phrase in the footer later once we decide on the final look/feel of spinnaker.io