### PR TITLE
docs(shortcodes): add "alpha" shortcode

### DIFF
--- a/content/en/docs/guides/developer/plugin-creators/stage-plugin-walkthrough.md
+++ b/content/en/docs/guides/developer/plugin-creators/stage-plugin-walkthrough.md
@@ -5,7 +5,7 @@ sidebar:
   nav: guides
 ---
 
-{% include alpha version="1.19.4" %}
+{{< alpha version="1.19.4" >}}
 > This guide is a work in progress. Help us improve the content by submitting a pull request!
 
 

--- a/layouts/shortcodes/alpha.html
+++ b/layouts/shortcodes/alpha.html
@@ -1,0 +1,14 @@
+<div class="alert alert-warning" role="alert">
+
+  <p>
+	 {{ with .Get "version" }}
+    The contents of this page refer to alpha features in Spinnaker
+    {{ . | safeHTML }}.
+	 {{ end }}
+  </p>
+  <p>
+    This means we are working on their stability and usability, as well as
+    possibly adding or changing features. Expect rough edges, and file <a
+    href="https://github.com/spinnaker/spinnaker/issues">issues</a> as needed.
+  </p>
+</div>


### PR DESCRIPTION
Shortcode to replace the Jekyll "alpha" include.

Usage:
Replace Jekyll  `{% include alpha version="1.19.4" %}` with `{{< alpha version="1.19.4" >}}`

Rendered output:
![image](https://user-images.githubusercontent.com/26799583/90026570-1b951800-dc7d-11ea-8d81-352b6c89849e.png)

Page with alpha shortcode:  https://deploy-preview-52--spinnaker-io.netlify.app/docs/guides/developer/plugin-creators/stage-plugin-walkthrough/