### PR TITLE
docs(theme-fix): move custom footer out of theme

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,66 @@
+{{ $links := .Site.Params.links }}
+<footer class="bg-white py-5 row d-print-none">
+  <div class="container-fluid mx-sm-5">
+    <div class="row row-divider">
+      <div class="col pb-5">
+        <hr />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-6 d-flex align-items-center text-xs-center order-sm-2">
+        {{ with $links }}
+        {{ with index . "developer"}}
+        {{ template "footer-links-block"  . }}
+        {{ end }}
+        {{ end }}
+      </div>
+      <div class="col-6 text-right text-xs-center order-sm-3 col-footer-logos">
+        {{/* {{ with $links }}
+        {{ with index . "developer"}}
+        {{ template "footer-links-block"  . }}
+        {{ end }}
+        {{ end }} */}}
+        <a href="https://cd.foundation/" target="_blank">
+          <img src="https://www.spinnaker.io/assets/images/cdf-color.png" alt="CD Foundation logo">
+        </a>
+        <a href="https://www.netlify.com">
+          <img src="https://www.netlify.com/img/global/badges/netlify-dark.svg" alt="Deploys by Netlify" />
+        </a>
+      </div>
+      <div class="col-12 col-sm-8 py-2 pt-4 mb-5 order-sm-3 col-copy">
+        {{ with .Site.Params.copyright }}<small class="text-dark">&copy; {{ now.Year}} {{ . | markdownify }} {{ T "footer_all_rights_reserved" }}</small>{{ end }}
+        {{ if or .Site.Params.privacy_policy .Site.Params.terms_of_use }}
+          <div class="copy-meta">
+            {{ with .Site.Params.privacy_policy }}
+              <small class="">
+                <a href="{{ . }}" target="_blank">{{ T "footer_privacy_policy" }}</a>
+              </small>
+            {{ end }}
+            {{ if and .Site.Params.privacy_policy .Site.Params.terms_of_use }}
+              |
+            {{ end }}
+            {{ with .Site.Params.terms_of_use }}
+              <small class="">
+                <a href="{{ . }}" target="_blank">{{ T "footer_terms_of_use" }}</a>
+              </small>
+            {{ end }}
+          	{{ if not .Site.Params.ui.footer_about_disable }}
+          		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
+          	{{ end }}
+          </div>
+        {{ end }}
+      </div>
+    </div>
+  </div>
+</footer>
+{{ define "footer-links-block" }}
+<ul class="list-inline mb-0">
+  {{ range . }}
+  <li class="list-inline-item mr-3 mb-2 mb-sm-0" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+    <a class="text-dark" target="_blank" href="{{ .url }}">
+      <i class="{{ .icon }} fa-2x"></i>
+    </a>
+  </li>
+  {{ end }}
+</ul>
+{{ end }}

--- a/themes/docsy-master/layouts/partials/footer.html
+++ b/themes/docsy-master/layouts/partials/footer.html
@@ -1,54 +1,27 @@
 {{ $links := .Site.Params.links }}
-<footer class="bg-white py-5 row d-print-none">
+<footer class="bg-dark py-5 row d-print-none">
   <div class="container-fluid mx-sm-5">
-    <div class="row row-divider">
-      <div class="col pb-5">
-        <hr />
-      </div>
-    </div>
     <div class="row">
-      <div class="col-6 d-flex align-items-center text-xs-center order-sm-2">
+      <div class="col-6 col-sm-4 text-xs-center order-sm-2">
+        {{ with $links }}
+        {{ with index . "user"}}
+        {{ template "footer-links-block"  . }}
+        {{ end }}
+        {{ end }}
+      </div>
+      <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3">
         {{ with $links }}
         {{ with index . "developer"}}
         {{ template "footer-links-block"  . }}
         {{ end }}
         {{ end }}
       </div>
-      <div class="col-6 text-right text-xs-center order-sm-3 col-footer-logos">
-        {{/* {{ with $links }}
-        {{ with index . "developer"}}
-        {{ template "footer-links-block"  . }}
-        {{ end }}
-        {{ end }} */}}
-        <a href="https://cd.foundation/" target="_blank">
-          <img src="https://www.spinnaker.io/assets/images/cdf-color.png" alt="CD Foundation logo">
-        </a>
-        <a href="https://www.netlify.com">
-          <img src="https://www.netlify.com/img/global/badges/netlify-dark.svg" alt="Deploys by Netlify" />
-        </a>
-      </div>
-      <div class="col-12 col-sm-8 py-2 pt-4 mb-5 order-sm-3 col-copy">
-        {{ with .Site.Params.copyright }}<small class="text-dark">&copy; {{ now.Year}} {{ . | markdownify }} {{ T "footer_all_rights_reserved" }}</small>{{ end }}
-        {{ if or .Site.Params.privacy_policy .Site.Params.terms_of_use }}
-          <div class="copy-meta">
-            {{ with .Site.Params.privacy_policy }}
-              <small class="">
-                <a href="{{ . }}" target="_blank">{{ T "footer_privacy_policy" }}</a>
-              </small>
-            {{ end }}
-            {{ if and .Site.Params.privacy_policy .Site.Params.terms_of_use }}
-              |
-            {{ end }}
-            {{ with .Site.Params.terms_of_use }}
-              <small class="">
-                <a href="{{ . }}" target="_blank">{{ T "footer_terms_of_use" }}</a>
-              </small>
-            {{ end }}
-          	{{ if not .Site.Params.ui.footer_about_disable }}
-          		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
-          	{{ end }}
-          </div>
-        {{ end }}
+      <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
+        {{ with .Site.Params.copyright }}<small class="text-white">&copy; {{ now.Year}} {{ .}} {{ T "footer_all_rights_reserved" }}</small>{{ end }}
+        {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}" target="_blank">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
+	{{ if not .Site.Params.ui.footer_about_disable }}
+		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
+	{{ end }}
       </div>
     </div>
   </div>
@@ -56,9 +29,9 @@
 {{ define "footer-links-block" }}
 <ul class="list-inline mb-0">
   {{ range . }}
-  <li class="list-inline-item mr-3 mb-2 mb-sm-0" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
-    <a class="text-dark" target="_blank" href="{{ .url }}">
-      <i class="{{ .icon }} fa-2x"></i>
+  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+    <a class="text-white" target="_blank" href="{{ .url }}">
+      <i class="{{ .icon }}"></i>
     </a>
   </li>
   {{ end }}


### PR DESCRIPTION
Move custom footer code out of theme and into project layouts folder.
This overrides PR https://github.com/spinnaker/spinnaker.io/pull/1

Overriding Docsy theme elements is best done in the project, not in the theme itself, as the Docsy docs recommend. Changing the theme directly could result in difficulties when we need to update the theme,  apply patches, update Hugo, etc.
https://www.docsy.dev/docs/adding-content/lookandfeel/#customizing-templates