### PR TITLE
docs(migration): add global redirects to account for the old + new url structure

### DIFF
--- a/content/en/docs/concepts/clusters/_index.md
+++ b/content/en/docs/concepts/clusters/_index.md
@@ -14,6 +14,6 @@ Also available are ad-hoc actions you can perform on the resources you see such 
 
 * On the left are filters for viewing your deployed services. You can search by string match, or narrow by specific attributes of your services, such as cloud platform, region, or your designated environments and stacks.
 
-* The main/center section lists the deployed services. Following the description in the [Concepts](/concepts/) page, you can see the grouping in action. Here, the green chiclets are individual instances (e.g. an EC2 VM instance, a Kubernetes Pod), grouped into Server Groups (a particular deployment), which are further grouped into Clusters.
+* The main/center section lists the deployed services. Following the description in the [Concepts](/docs/concepts/) page, you can see the grouping in action. Here, the green chiclets are individual instances (e.g. an EC2 VM instance, a Kubernetes Pod), grouped into Server Groups (a particular deployment), which are further grouped into Clusters.
 
 * The right section provides details for the item currently selected in the center section. For each item, Spinnaker provides details related to both application-level concerns (Jenkins job details) as well as infrastructure-level concerns (machine type, auto-scaling policies).

--- a/content/en/docs/concepts/ebook/_index.md
+++ b/content/en/docs/concepts/ebook/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Ebook: Continuous Delivery With Spinnaker"
-linkTitle: "Ebook"
+linkTitle: "Spinnaker Ebook"
 weight: 2
 description: "Using Netflix and its open source Spinnaker CD platform as examples, the Continuous Delivery with Spinnaker ebook demonstrates how a new host of tools can help you deploy software changes to production quickly, safely, and automatically."
 ---

--- a/content/en/docs/setup/_index.md
+++ b/content/en/docs/setup/_index.md
@@ -11,23 +11,23 @@ These pages contain instructions for installing and setting up Spinnaker
 ## Try it out
 
 If you're new to Spinnaker and you want a quick way to evaluate it, try out one
-of the [quickstart solutions](/docs/v1.19/setup/quickstart/). These are demos for
+of the [quickstart solutions](/docs/setup/quickstart/). These are demos for
 evaluation only and are not suitable for use in production.
 
 ## Install it
 
 If you want a more serious, scalable deployment of Spinnaker continue
-[here](/docs/v1.19/setup/install/) to installation guide. All other
+[here](/docs/setup/install/) to installation guide. All other
 resources on this Setup page will assume you're following those instructions.
 
 ## Find out more
 
 * If you're curious how Spinnaker works, take a look at the
-  [Spinnaker Architecture](/docs/v1.19/reference/architecture/).
+  [Spinnaker Architecture](/docs/reference/architecture/).
 * Take a look at the [Releases](/community/releases/) page to pick a version of
   Spinnaker to install.
 
 ## Then what?
 
 After you've done all this setup stuff, go to [Get started using
-Spinnaker](/docs/v1.19/guides/user/get-started/) to get to work.
+Spinnaker](/docs/guides/user/get-started/) to get to work.

--- a/content/en/docs/setup/artifacts/_index.md
+++ b/content/en/docs/setup/artifacts/_index.md
@@ -7,6 +7,6 @@ description: >
 ---
 
 Artifacts are remote, deployable resources in Spinnaker. Depending on
-their ["type"](/docs/v1.19/reference/artifacts), they will need credentials to be
+their ["type"](/docs/reference/artifacts), they will need credentials to be
 downloaded or uploaded. These pages take you through configuring those
 credentials.

--- a/content/en/docs/setup/artifacts/bitbucket.md
+++ b/content/en/docs/setup/artifacts/bitbucket.md
@@ -25,7 +25,7 @@ account with the needed credentials to read your artifact.
 1. Collect the `$USERNAME_PASSWORD_FILE` value returned from the
    [prerequisites](#prerequisites) section above.
    
-2. Enable [artifact support](/docs/v1.19/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
+2. Enable [artifact support](/docs/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 
 
 2. Enable the Bitbucket artifact provider:

--- a/content/en/docs/setup/artifacts/oracle.md
+++ b/content/en/docs/setup/artifacts/oracle.md
@@ -10,7 +10,7 @@ Spinnaker stages that read data from artifacts can consume
 
 ## Prerequisites
 
-If you have enabled [Oracle Cloud provider](/docs/v1.19/setup/install/providers/oracle/) in Spinnaker, you may use the same region, Tenancy’s OCID, user’s OCID, private key file, and fingerprint to enable Oracle Object Storage Artifact. You will need the following to enable Oracle Object Storage Artifact in Spinnaker:
+If you have enabled [Oracle Cloud provider](/docs/setup/install/providers/oracle/) in Spinnaker, you may use the same region, Tenancy’s OCID, user’s OCID, private key file, and fingerprint to enable Oracle Object Storage Artifact. You will need the following to enable Oracle Object Storage Artifact in Spinnaker:
 
 * A user in IAM for the person or system who will be using Spinnaker, and that user must be granted access to Object Storage or in one IAM group with permissions of Object Storage.
 

--- a/content/en/docs/setup/bakery/_index.md
+++ b/content/en/docs/setup/bakery/_index.md
@@ -47,5 +47,5 @@ stage UI to refer to your custom template:
 
 The following providers support configuring their image bakery:
 
-* [Google Compute Engine](/docs/v1.19/setup/bakery/google/)
-* [Oracle Cloud Infrastructure](/docs/v1.19/setup/bakery/oracle/)
+* [Google Compute Engine](/docs/setup/bakery/google/)
+* [Oracle Cloud Infrastructure](/docs/setup/bakery/oracle/)

--- a/content/en/docs/setup/canary/_index.md
+++ b/content/en/docs/setup/canary/_index.md
@@ -119,7 +119,7 @@ hal config canary edit --default-metrics-account ACCOUNT
 
 ## Provide the default storage account
 
-Add the account name for your [storage provider](/docs/v1.19/setup/install/storage).
+Add the account name for your [storage provider](/docs/setup/install/storage).
 This default can be overridden in [canary
 configuration](/guides/user/canary/config/).
 

--- a/content/en/docs/setup/ci/_index.md
+++ b/content/en/docs/setup/ci/_index.md
@@ -23,10 +23,10 @@ independently of one-another, enumerated below.
 
 These are the CI systems currently supported by Spinnaker:
 
-* [AWS CodeBuild](/docs/v1.19/setup/ci/codebuild/)
-* [Google Cloud Build](/docs/v1.19/setup/ci/gcb/)
-* [Jenkins](/docs/v1.19/setup/ci/jenkins/)
-* [Travis CI](/docs/v1.19/setup/ci/travis/)
-* [Wercker](/docs/v1.19/setup/ci/wercker/)
+* [AWS CodeBuild](/docs/setup/ci/codebuild/)
+* [Google Cloud Build](/docs/setup/ci/gcb/)
+* [Jenkins](/docs/setup/ci/jenkins/)
+* [Travis CI](/docs/setup/ci/travis/)
+* [Wercker](/docs/setup/ci/wercker/)
 
 See also [`hal config ci`](/reference/halyard/commands/#hal-config-ci).

--- a/content/en/docs/setup/ci/codebuild.md
+++ b/content/en/docs/setup/ci/codebuild.md
@@ -116,7 +116,7 @@ Configure your pipeline to get triggered when an AWS CodeBuild build completes:
 set up a notification rule for your project. To trigger the pipeline on completion of the build,
 select **Succeeded** and **Failed** in the **Events that trigger notifications** section under **Build state**.
 
-2. Follow these [instructions](/docs/v1.19/setup/triggers/amazon/) to create an Amazon Pub/Sub trigger. Keep the following guidelines in mind:
+2. Follow these [instructions](/docs/setup/triggers/amazon/) to create an Amazon Pub/Sub trigger. Keep the following guidelines in mind:
   - Skip the step to create SNS topic, as we will use the SNS topic created in step 1.
   - Create an SQS queue and subscribe the queue to the SNS topic.
   - Skip the step to create an S3 bucket, as the notification will be sent from CodeBuild instead of from S3.

--- a/content/en/docs/setup/ci/gcb.md
+++ b/content/en/docs/setup/ci/gcb.md
@@ -104,7 +104,7 @@ To run a GCB build as part of a Spinnaker pipeline:
 
 2. Configure the stage by selecting the GCB account to use to run the build, and entering the
 [build configuration YAML](https://cloud.google.com/cloud-build/docs/build-config) in the provided text box:
-![](/docs/v1.19/setup/ci/gcb_config.png)
+![](/docs/setup/ci/gcb_config.png)
 You may also provide the build definition YAML as an artifact.
 
 3. In the *Produces Artifacts* section, you may supply any artifacts that you expect the build to create in order to
@@ -114,7 +114,7 @@ will be converted to Spinnaker artifacts and injected into the pipeline on compl
 
 While your build is executing, the stage details will provide the current status of the build and a link to view
 the build logs in the Google Cloud Console:
-![](/docs/v1.19/setup/ci/gcb_status.png)
+![](/docs/setup/ci/gcb_status.png)
 
 ## Configuration prior to Spinnaker 1.14
 

--- a/content/en/docs/setup/ci/jenkins.md
+++ b/content/en/docs/setup/ci/jenkins.md
@@ -88,7 +88,7 @@ To enable Spinnaker and Jenkins to share a crumb to protect against CSRF...
 
     a. Under __Manage Jenkins__ > __Plugin Manager__ > __Available__, search for __Strict Crumb Issuer Plugin__, select __Install__
 
-    ![](/docs/v1.19/setup/ci/strict_crumb_issuer_plugin_install.png)
+    ![](/docs/setup/ci/strict_crumb_issuer_plugin_install.png)
 
 3. Enable CSRF protection in Jenkins:
 
@@ -99,7 +99,7 @@ To enable Spinnaker and Jenkins to share a crumb to protect against CSRF...
 
     c. Under __Strict Crumb Issuer__ > __Advanced__, deselect __Check the session ID__
 
-    ![](/docs/v1.19/setup/ci/jenkins_enable_csrf_strict.png)
+    ![](/docs/setup/ci/jenkins_enable_csrf_strict.png)
 
 ## Next steps
 
@@ -114,4 +114,4 @@ Jenkins or run the Jenkins stage. This is sufficient for most use cases. See
 for more information.
 
 Using the Script stage requires further configuration. See [Configuring
-the Script Stage](/docs/v1.19/setup/features/script-stage/) to finish setting it up.
+the Script Stage](/docs/setup/features/script-stage/) to finish setting it up.

--- a/content/en/docs/setup/features/script-stage/index.md
+++ b/content/en/docs/setup/features/script-stage/index.md
@@ -21,7 +21,7 @@ To configure a Script stage, you need:
 *   A running Jenkins instance at `$JENKINS_HOST`, with a Jenkins user profile set up
     with access to create jobs
 *   A running Spinnaker instance, with access to configuration files, and in
-    which you have [set up Jenkins on Spinnaker](/docs/v1.19/setup/ci/jenkins/)
+    which you have [set up Jenkins on Spinnaker](/docs/setup/ci/jenkins/)
 
 ## Configure Jenkins
 

--- a/content/en/docs/setup/install/_index.md
+++ b/content/en/docs/setup/install/_index.md
@@ -9,7 +9,7 @@ description: >
 
 This section describes how to install and set up Spinnaker so that it can be configured for
 use in production. If you just want to evaluate Spinnaker without much work, one of the options
-in [Quickstart](/docs/v1.19/setup/quickstart/) might be a better choice.
+in [Quickstart](/docs/setup/quickstart/) might be a better choice.
 
 ## What you'll need
 
@@ -27,15 +27,15 @@ You can also install [on a single local machine](https://www.spinnaker.io/setup/
 ## The process
 
 Installing a complete Spinnaker involves these steps:
-1. [Install Halyard](/docs/v1.19/setup/install/halyard/)
-1. [Choose a cloud provider](/docs/v1.19/setup/install/providers/)
-1. [Choose an environment](/docs/v1.19/setup/install/environment/)
-1. [Choose a storage service](/docs/v1.19/setup/install/storage/)
-1. [Deploy Spinnaker](/docs/v1.19/setup/install/deploy/)
-1. [Back up your config](/docs/v1.19/setup/install/backups/)
-1. [Configure everything else](/docs/v1.19/setup/other_config/) (which includes a lot of
+1. [Install Halyard](/docs/setup/install/halyard/)
+1. [Choose a cloud provider](/docs/setup/install/providers/)
+1. [Choose an environment](/docs/setup/install/environment/)
+1. [Choose a storage service](/docs/setup/install/storage/)
+1. [Deploy Spinnaker](/docs/setup/install/deploy/)
+1. [Back up your config](/docs/setup/install/backups/)
+1. [Configure everything else](/docs/setup/other_config/) (which includes a lot of
   stuff you need before you can use Spinnaker in production)
-1. [Productionize Spinnaker](/docs/v1.19/setup/productionize/) (which mainly helps you
+1. [Productionize Spinnaker](/docs/setup/productionize/) (which mainly helps you
   configure Spinnaker to scale for production)
 
 ## And then what?

--- a/content/en/docs/setup/install/backups.md
+++ b/content/en/docs/setup/install/backups.md
@@ -43,4 +43,4 @@ backup.
 ## Next steps
 
 After this step is done, you can use Spinnaker to create pipelines and deploy software, 
-but there are some [further configuration steps](/docs/v1.19/setup/other_config/) you're likely to need.
+but there are some [further configuration steps](/docs/setup/other_config/) you're likely to need.

--- a/content/en/docs/setup/install/configuration.md
+++ b/content/en/docs/setup/install/configuration.md
@@ -19,7 +19,7 @@ hal deploy apply
 
 ### Deploy to more environments
 
-[Documentation](/docs/v1.19/setup/providers/) -- `hal config provider`
+[Documentation](/docs/setup/providers/) -- `hal config provider`
 
 You can add more Accounts to as many Providers as you want. There is nothing
 preventing you from deploying to two Kubernetes clusters, one Google Compute
@@ -27,7 +27,7 @@ Engine project, and an App Engine application all at once.
 
 ### Edit your storage settings
 
-[Documentation](/docs/v1.19/setup/install/storage/) -- `hal config storage`
+[Documentation](/docs/setup/install/storage/) -- `hal config storage`
 
 While you have likely already setup a storage source during the initial
 installation of Spinnaker, you can always reconfigure it. However, it is up to
@@ -35,27 +35,27 @@ you to migrate any data that you depend on.
 
 ### Secure your Spinnaker installation
 
-[Documentation](/docs/v1.19/setup/security/) -- `hal config security`
+[Documentation](/docs/setup/security/) -- `hal config security`
 
 You can configure SSL, setup a login page, or apply role-based authorization.
 
 ### Setup continuous integration
 
-[Documentation](/docs/v1.19/setup/ci/) -- `hal config ci`
+[Documentation](/docs/setup/ci/) -- `hal config ci`
 
 Configure Jenkins or Travis CI to trigger Pipelines or supply Spinnaker with
 build artifacts to build into images and deploy.
 
 ### Configure notifications
 
-[Documentation](/docs/v1.19/setup/features/notifications/) -- ` `
+[Documentation](/docs/setup/features/notifications/) -- ` `
 
 Enable notifications to be sent on Spinnaker events, and allow external events
 to trigger Pipelines in Spinnaker.
 
 ### Monitor your Spinnaker installation
 
-[Documentation](/docs/v1.19/setup/monitoring/) -- `hal config metric-stores`
+[Documentation](/docs/setup/monitoring/) -- `hal config metric-stores`
 
 Publish timeseries data from your Spinnaker installation to a variety of
 metric sources into curated dashboards. This is useful for understanding how
@@ -64,4 +64,4 @@ to scale and troubleshoot your deployment of Spinnaker.
 ## Next steps
 
 Now that you know how to make configuration changes, it's worth learning how to
-[Upgrade Spinnaker](/docs/v1.19/setup/install/upgrades/).
+[Upgrade Spinnaker](/docs/setup/install/upgrades/).

--- a/content/en/docs/setup/install/deploy.md
+++ b/content/en/docs/setup/install/deploy.md
@@ -6,9 +6,9 @@ sidebar:
 redirect_from: /setup/install/upgrades/
 ---
 
-Now that we've enabled one or more [Cloud Providers](/docs/v1.19/setup/providers/), picked
-a [Deployment Environment](/docs/v1.19/setup/install/environment/), and configured
-[Persistent Storage](/docs/v1.19/setup/install/storage/), we're ready to pick a version of
+Now that we've enabled one or more [Cloud Providers](/docs/setup/providers/), picked
+a [Deployment Environment](/docs/setup/install/environment/), and configured
+[Persistent Storage](/docs/setup/install/storage/), we're ready to pick a version of
 Spinnaker, deploy it, and connect to it.
 
 ## Pick a version
@@ -66,12 +66,12 @@ provider (such as `kubectl get pods --namespace spinnaker`).
 
 * You can make Spinnaker publicly reachable without running this command,
 as described
-[here](/docs/v1.19/setup/quickstart/faq//#i-want-to-expose-localdebian-spinnaker-on-a-public-ip-address-but-it-always-binds-to-localhost)
+[here](/docs/setup/quickstart/faq//#i-want-to-expose-localdebian-spinnaker-on-a-public-ip-address-but-it-always-binds-to-localhost)
 (for local Debian) and
-[here](/docs/v1.19/setup/quickstart/faq/#i-want-to-expose-the-distributed-kubernetes-hosted-spinnaker-publicly)
+[here](/docs/setup/quickstart/faq/#i-want-to-expose-the-distributed-kubernetes-hosted-spinnaker-publicly)
 (for Kubernetes).
 
-* You can [set up authentication](/docs/v1.19/setup/security/authentication/).
+* You can [set up authentication](/docs/setup/security/authentication/).
 
 ## Troubleshooting
 
@@ -105,11 +105,11 @@ Now that Spinnaker is deployed and capable managing your cloud provider, you
 can...
 
 * Continue with additional configuration, such as your [image
-bakery](/docs/v1.19/setup/bakery/)
+bakery](/docs/setup/bakery/)
 
 * If you're a Spinnaker end user, read how to [get started using
 Spinnaker](/guides/user/get-started)
 
 * Visit the [Guides](/guides/) pages to learn more
 
-You might also want to [back up your configuration](/docs/v1.19/setup/install/backups/).
+You might also want to [back up your configuration](/docs/setup/install/backups/).

--- a/content/en/docs/setup/install/environment.md
+++ b/content/en/docs/setup/install/environment.md
@@ -53,7 +53,7 @@ which you will install Spinnaker.
    This must be on a Kubernetes cluster. It does not have to be the same
    provider as the one you're using to deploy your applications.
 
-   * [Kubernetes](/docs/v1.19/setup/install/providers/kubernetes-v2)
+   * [Kubernetes](/docs/setup/install/providers/kubernetes-v2)
 
    We recommend at least 4 cores and 16GB of RAM available in the cluster where
    you will deploy Spinnaker.
@@ -217,4 +217,4 @@ hal config version edit --version branch:upstream/master
 ## Next steps
 
 Now that your deployment environment is set up, you need to provide Spinnaker
-with a [Persistent Storage](/docs/v1.19/setup/install/storage/) source.
+with a [Persistent Storage](/docs/setup/install/storage/) source.

--- a/content/en/docs/setup/install/halyard.md
+++ b/content/en/docs/setup/install/halyard.md
@@ -195,4 +195,4 @@ To uninstall Halyard, just delete the container.
 
 ## Next steps
 
-Now that Halyard is running, it's time to [choose your cloud provider](/docs/v1.19/setup/install/providers/).
+Now that Halyard is running, it's time to [choose your cloud provider](/docs/setup/install/providers/).

--- a/content/en/docs/setup/install/providers/_index.md
+++ b/content/en/docs/setup/install/providers/_index.md
@@ -22,14 +22,14 @@ anything you must enable at least one provider, with one Account added for it.
 
 Add as many of the following providers as you need. When you're done, return to this page.
 
-* [App Engine](/docs/v1.19/setup/install/providers/appengine/)
-* [Amazon Web Services](/docs/v1.19/setup/install/providers/aws/)
-* [Azure](/docs/v1.19/setup/install/providers/azure/)
-* [Cloud Foundry](/docs/v1.19/setup/install/providers/cf/)
-* [DC/OS](/docs/v1.19/setup/install/providers/dcos/)
-* [Google Compute Engine](/docs/v1.19/setup/install/providers/gce/)
-* [Kubernetes](/docs/v1.19/setup/install/providers/kubernetes-v2/)
-* [Oracle](/docs/v1.19/setup/install/providers/oracle/)
+* [App Engine](/docs/setup/install/providers/appengine/)
+* [Amazon Web Services](/docs/setup/install/providers/aws/)
+* [Azure](/docs/setup/install/providers/azure/)
+* [Cloud Foundry](/docs/setup/install/providers/cf/)
+* [DC/OS](/docs/setup/install/providers/dcos/)
+* [Google Compute Engine](/docs/setup/install/providers/gce/)
+* [Kubernetes](/docs/setup/install/providers/kubernetes-v2/)
+* [Oracle](/docs/setup/install/providers/oracle/)
 
 See also [`hal config provider`](/reference/halyard/commands/#hal-config-provider)
 for command reference documentation.
@@ -37,4 +37,4 @@ for command reference documentation.
 ## Next steps
 
 When you've finished setting up your cloud provider, you're ready to
-[choose an environment](/docs/v1.19/setup/install/environment/).
+[choose an environment](/docs/setup/install/environment/).

--- a/content/en/docs/setup/install/providers/_index.md
+++ b/content/en/docs/setup/install/providers/_index.md
@@ -1,10 +1,10 @@
 ---
 layout: single
 title:  "Choose Cloud Providers"
-sidebar:
-  nav: setup
-redirect_from: /docs/target-deployment-setup
-redirect_from: /setup/providers/
+aliases: 
+  - /docs/target-deployment-setup
+  - /setup/providers/
+  - /docs/setup/providers/
 ---
 
 In Spinnaker, *Providers* are integrations to the Cloud platforms you deploy

--- a/content/en/docs/setup/install/providers/appengine.md
+++ b/content/en/docs/setup/install/providers/appengine.md
@@ -128,6 +128,6 @@ you can use an **Artifact** as the source of the container image URL.
 
 ## Next steps
 
-Optionally, you can [set up another cloud provider](/docs/v1.19/setup/install/providers/),
-but otherwise you're ready to [choose an environment](/docs/v1.19/setup/install/environment/)
+Optionally, you can [set up another cloud provider](/docs/setup/install/providers/),
+but otherwise you're ready to [choose an environment](/docs/setup/install/environment/)
 in which to install Spinnaker.

--- a/content/en/docs/setup/install/providers/aws/aws-ec2.md
+++ b/content/en/docs/setup/install/providers/aws/aws-ec2.md
@@ -131,7 +131,7 @@ You can view the available configuration flags for AWS within the
 ## Next steps
 
 Optionally, you can [set up Amazon's Elastic Container
-Service](/docs/v1.19/setup/install/providers/aws/aws-ecs/) or [set up another cloud
-provider](/docs/v1.19/setup/install/providers/), but otherwise you're ready to
-[choose an environment](/docs/v1.19/setup/install/environment/)
+Service](/docs/setup/install/providers/aws/aws-ecs/) or [set up another cloud
+provider](/docs/setup/install/providers/), but otherwise you're ready to
+[choose an environment](/docs/setup/install/environment/)
 in which to install Spinnaker.

--- a/content/en/docs/setup/install/providers/aws/aws-ecs.md
+++ b/content/en/docs/setup/install/providers/aws/aws-ecs.md
@@ -58,7 +58,7 @@ The IAM role for the cloud provider account associated with the Amazon ECS serve
 }
 ```
 
-For information on how to configure the IAM role associated with the cloud provider account, see the [AWS provider documentation](/docs/v1.19/setup/install/providers/aws/aws-ec2/).  For information on how to modify IAM roles in the AWS console, see the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_modify.html){:target="\_blank"}.
+For information on how to configure the IAM role associated with the cloud provider account, see the [AWS provider documentation](/docs/setup/install/providers/aws/aws-ec2/).  For information on how to modify IAM roles in the AWS console, see the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_modify.html){:target="\_blank"}.
 
 ### Task Execution IAM Role
 
@@ -83,7 +83,7 @@ If you are not using a task definition artifact (or if the artifact's task defin
 }
 ```
 
-For information on how to configure the IAM role associated with the cloud provider account, see the [AWS provider documentation](/docs/v1.19/setup/install/providers/aws/aws-ec2/).  For information on how to modify IAM roles in the AWS console, see the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_modify.html){:target="\_blank"}.
+For information on how to configure the IAM role associated with the cloud provider account, see the [AWS provider documentation](/docs/setup/install/providers/aws/aws-ec2/).  For information on how to modify IAM roles in the AWS console, see the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_modify.html){:target="\_blank"}.
 
 ### Optional: IAM Roles for Tasks
 
@@ -158,6 +158,6 @@ ecs:
 
 ## Next steps
 
-Optionally, you can [set up another cloud provider](/docs/v1.19/setup/install/providers/),
-but otherwise you're ready to [choose an environment](/docs/v1.19/setup/install/environment/)
+Optionally, you can [set up another cloud provider](/docs/setup/install/providers/),
+but otherwise you're ready to [choose an environment](/docs/setup/install/environment/)
 in which to install Spinnaker.

--- a/content/en/docs/setup/install/providers/aws/index.md
+++ b/content/en/docs/setup/install/providers/aws/index.md
@@ -37,6 +37,6 @@ Refer to [AWS IAM Providing Access to multiple AWS Accounts](https://docs.aws.am
 
 There are several ways to configure the Amazon Web Services (AWS) Cloud Provider. Choose one or more based on your requirements:
 
-* [Amazon Elastic Compute Cloud (EC2)](/docs/v1.19/setup/install/providers/aws/aws-ec2/) - - Use this option, if you want to manage [EC2 Instances](https://aws.amazon.com/ec2/) via Spinnaker
-* [Amazon Elastic Container Service (ECS)](/docs/v1.19/setup/install/providers/aws/aws-ecs/) - Use this option, if you want to manage containers in [Amazon ECS](https://aws.amazon.com/ecs/)
-* [Amazon Elastic Kubernetes Service (EKS)](/docs/v1.19/setup/install/providers/kubernetes-v2/aws-eks/) - Use this option, if you want to manage containers in [Amazon EKS](https://aws.amazon.com/eks/). This option uses [Kubernetes V2 (manifest based) Clouddriver](/docs/v1.19/setup/install/providers/kubernetes-v2)
+* [Amazon Elastic Compute Cloud (EC2)](/docs/setup/install/providers/aws/aws-ec2/) - - Use this option, if you want to manage [EC2 Instances](https://aws.amazon.com/ec2/) via Spinnaker
+* [Amazon Elastic Container Service (ECS)](/docs/setup/install/providers/aws/aws-ecs/) - Use this option, if you want to manage containers in [Amazon ECS](https://aws.amazon.com/ecs/)
+* [Amazon Elastic Kubernetes Service (EKS)](/docs/setup/install/providers/kubernetes-v2/aws-eks/) - Use this option, if you want to manage containers in [Amazon EKS](https://aws.amazon.com/eks/). This option uses [Kubernetes V2 (manifest based) Clouddriver](/docs/setup/install/providers/kubernetes-v2)

--- a/content/en/docs/setup/install/providers/azure.md
+++ b/content/en/docs/setup/install/providers/azure.md
@@ -110,6 +110,6 @@ You can view the available configuration flags for Azure within the
 
 ## Next steps
 
-Optionally, you can [set up another cloud provider](/docs/v1.19/setup/install/providers/),
-but otherwise you're ready to [choose an environment](/docs/v1.19/setup/install/environment/)
+Optionally, you can [set up another cloud provider](/docs/setup/install/providers/),
+but otherwise you're ready to [choose an environment](/docs/setup/install/environment/)
 in which to install Spinnaker.

--- a/content/en/docs/setup/install/providers/dcos.md
+++ b/content/en/docs/setup/install/providers/dcos.md
@@ -11,7 +11,7 @@ redirect_from: /setup/providers/dcos/
 DC/OS configuration for Spinnaker consists of a set of DC/OS
 clusters and a set of [Accounts](/concepts/providers/#accounts) that have
 credentials to authenticate to one or more of those clusters.
-Additionally, each account has a set of [Docker Registry](/docs/v1.19/setup/providers/docker-registry)
+Additionally, each account has a set of [Docker Registry](/docs/setup/providers/docker-registry)
 accounts to be used as a source of images.
 
 ## Prerequisites
@@ -28,7 +28,7 @@ has not been extensively tested.
 
 ### Docker registries
 
-Follow the steps under the [Docker Registry](/docs/v1.19/setup/providers/docker-registry)
+Follow the steps under the [Docker Registry](/docs/setup/providers/docker-registry)
 provider to add any registries containing images you want to deploy. If
 you have already done so, you can verify that these accounts exist by running:
 
@@ -94,6 +94,6 @@ and [clusters](/reference/halyard/commands/#hal-config-provider-dcos-cluster-add
 
 ## Next steps
 
-Optionally, you can [set up another cloud provider](/docs/v1.19/setup/install/providers/),
-but otherwise you're ready to [choose an environment](/docs/v1.19/setup/install/environment/)
+Optionally, you can [set up another cloud provider](/docs/setup/install/providers/),
+but otherwise you're ready to [choose an environment](/docs/setup/install/environment/)
 in which to install Spinnaker.

--- a/content/en/docs/setup/install/providers/docker-registry.md
+++ b/content/en/docs/setup/install/providers/docker-registry.md
@@ -18,8 +18,8 @@ repositories](https://docs.docker.com/glossary/?term=repository){:target="\_blan
 
 Perform the steps in this article in the same place where you have Halyard
 installed, whether [in a Docker
-container](/docs/v1.19/setup/install/halyard/#install-halyard-on-docker) or [locally on
-Ubuntu/Debian or macOS](/docs/v1.19/setup/install/halyard/#update-halyard-on-debianubuntu-or-macos).
+container](/docs/setup/install/halyard/#install-halyard-on-docker) or [locally on
+Ubuntu/Debian or macOS](/docs/setup/install/halyard/#update-halyard-on-debianubuntu-or-macos).
 
 ## Prerequisites
 
@@ -151,7 +151,7 @@ API](https://console.developers.google.com/apis/api/cloudresourcemanager.googlea
 1. Add the account.
 
    > Note: if you're running Halyard [in a Docker
-   > container](/docs/v1.19/setup/install/halyard/#install-halyard-on-docker), you might
+   > container](/docs/setup/install/halyard/#install-halyard-on-docker), you might
    > have to restart the container, now mounting the `~/.gcp` directory.
 
    ```bash
@@ -260,6 +260,6 @@ Reference](/reference/halyard/commands#hal-config-provider-docker-registry-accou
 
 ## Next Steps
 
-Optionally, you can [set up another cloud provider](/docs/v1.19/setup/install/providers/),
-but otherwise you're ready to [choose an environment](/docs/v1.19/setup/install/environment/)
+Optionally, you can [set up another cloud provider](/docs/setup/install/providers/),
+but otherwise you're ready to [choose an environment](/docs/setup/install/environment/)
 in which to install Spinnaker.

--- a/content/en/docs/setup/install/providers/gce.md
+++ b/content/en/docs/setup/install/providers/gce.md
@@ -116,6 +116,6 @@ Reference](/reference/halyard/commands#hal-config-provider-google-account-add).
 
 ## Next steps
 
-Optionally, you can [set up another cloud provider](/docs/v1.19/setup/install/providers/),
-but otherwise you're ready to [choose an environment](/docs/v1.19/setup/install/environment/)
+Optionally, you can [set up another cloud provider](/docs/setup/install/providers/),
+but otherwise you're ready to [choose an environment](/docs/setup/install/environment/)
 in which to install Spinnaker.

--- a/content/en/docs/setup/install/providers/kubernetes-v2/ack/index.md
+++ b/content/en/docs/setup/install/providers/kubernetes-v2/ack/index.md
@@ -30,4 +30,4 @@ scp root@$MASTER:/etc/kubernetes/kube.conf $HOME/.kube/config
 ## Next Steps
 
 [Follow the setup instructions for adding a Kubernetes account in
-Spinnaker](/docs/v1.19/setup/install/providers/kubernetes-v2/#adding-an-account).
+Spinnaker](/docs/setup/install/providers/kubernetes-v2/#adding-an-account).

--- a/content/en/docs/setup/install/providers/kubernetes-v2/gke/index.md
+++ b/content/en/docs/setup/install/providers/kubernetes-v2/gke/index.md
@@ -50,14 +50,14 @@ account in order to generate an authentication token.
 Given that all pods on GKE share the same service account, granting Spinnaker
 on GKE permission also grants permission to all pods running alongside
 Spinnaker. For this reason, we recommend configuring a [Kubernetes service
-account](/docs/v1.19/setup/install/providers/kubernetes-v2/#optional-create-a-kubernetes-service-account)
+account](/docs/setup/install/providers/kubernetes-v2/#optional-create-a-kubernetes-service-account)
 for Spinnaker to authenticate as.
 
 __TL;DR__ Use the credentials you've downloaded to create a [Kubernetes service
-account](/docs/v1.19/setup/install/providers/kubernetes-v2/#optional-create-a-kubernetes-service-account)
+account](/docs/setup/install/providers/kubernetes-v2/#optional-create-a-kubernetes-service-account)
 for Spinnaker to authenticate as.
 
 ## Next steps
 
 [Follow the setup instructions for adding a Kubernetes account in
-Spinnaker](/docs/v1.19/setup/install/providers/kubernetes-v2/#adding-an-account).
+Spinnaker](/docs/setup/install/providers/kubernetes-v2/#adding-an-account).

--- a/content/en/docs/setup/install/providers/kubernetes.md
+++ b/content/en/docs/setup/install/providers/kubernetes.md
@@ -9,14 +9,14 @@ redirect_from:
 ---
 
 > ⚠️ Spinnaker's legacy Kubernetes provider (V1) is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md) in Spinnaker 1.21.
-> We recommend using the [standard provider (V2)](/docs/v1.19/setup/install/providers/kubernetes-v2) instead. 
+> We recommend using the [standard provider (V2)](/docs/setup/install/providers/kubernetes-v2) instead. 
 
 
 
 For the Kubernetes provider, a Spinnaker [Account](/concepts/providers/#accounts)
 maps to a credential that can authenticate against your Kubernetes Cluster. It
 also includes a set of one or more [Docker
-Registry](/docs/v1.19/setup/providers/docker-registry) accounts that are used as a source
+Registry](/docs/setup/providers/docker-registry) accounts that are used as a source
 of images.
 
 When setting up your Kubernetes provider account, you will [use halyard to add
@@ -68,7 +68,7 @@ The simplest way to get credentials is to use legacy authorization.
 
 1. Enable Legacy authorization.
 
-   ![](/docs/v1.19/setup/install/providers/images/gke-enable-legacy-auth.png)
+   ![](/docs/setup/install/providers/images/gke-enable-legacy-auth.png)
 
 1. Configure `gcloud` to populate the `kubeconfig` with
 [legacy credentials](https://cloud.google.com/kubernetes-engine/docs/how-to/iam-integration#using_legacy_cluster_certificate_or_user_credentials){:target=""\_blank"}:
@@ -93,7 +93,7 @@ However, [you can also use RBAC and a service account](#optional-configure-kuber
 
 To use the Kubernetes (legacy) provider, you need a Docker registry as a source
 of images. To enable this, [set up a Docker registry as another
-provider](/docs/v1.19/setup/providers/docker-registry), and add any registries that
+provider](/docs/setup/providers/docker-registry), and add any registries that
 contain images you want to deploy.
 
 You can verify your Docker registry accounts using this command:
@@ -190,6 +190,6 @@ If you are looking for more configurability, see the available options in the
 
 ## Next steps
 
-Optionally, you can [set up another cloud provider](/docs/v1.19/setup/install/providers/),
-but otherwise you're ready to [choose the environment](/docs/v1.19/setup/install/environment/)
+Optionally, you can [set up another cloud provider](/docs/setup/install/providers/),
+but otherwise you're ready to [choose the environment](/docs/setup/install/environment/)
 in which to install Spinnaker.

--- a/content/en/docs/setup/install/storage/_index.md
+++ b/content/en/docs/setup/install/storage/_index.md
@@ -12,7 +12,7 @@ costly to lose, we recommend you use a hosted storage solution you are confident
 in.
 
 Spinnaker supports the storage providers listed below. Whichever option you
-choose does not affect your choice of [Cloud Provider](/docs/v1.19/setup/providers/).
+choose does not affect your choice of [Cloud Provider](/docs/setup/providers/).
 That is, you can use [Google Cloud
 Storage](https://cloud.google.com/storage/){:target="\_blank"} as a storage
 source but still deploy to [Microsoft Azure](https://azure.microsoft.com/){:target="\_blank"}.
@@ -22,16 +22,16 @@ source but still deploy to [Microsoft Azure](https://azure.microsoft.com/){:targ
 Set up persistent storage for your Spinnaker instance by choosing one of the options below. When you've
 completed the section, return to this page.
 
-* [Azure Storage](/docs/v1.19/setup/install/storage/azs)
-* [Google Cloud Storage](/docs/v1.19/setup/install/storage/gcs)
-* [Minio](/docs/v1.19/setup/install/storage/minio)
-* [Redis](/docs/v1.19/setup/install/storage/redis) :warning: Unsupported and not recommended for production environments
-* [S3](/docs/v1.19/setup/install/storage/s3)
-* [Oracle Object Storage](/docs/v1.19/setup/install/storage/oracle)
+* [Azure Storage](/docs/setup/install/storage/azs)
+* [Google Cloud Storage](/docs/setup/install/storage/gcs)
+* [Minio](/docs/setup/install/storage/minio)
+* [Redis](/docs/setup/install/storage/redis) :warning: Unsupported and not recommended for production environments
+* [S3](/docs/setup/install/storage/s3)
+* [Oracle Object Storage](/docs/setup/install/storage/oracle)
 
 
 See also [`hal config storage`](/reference/halyard/commands/#hal-config-storage).
 
 ## Next steps
 
-After you've set up your external storage service, you're ready to [deploy Spinnaker](/docs/v1.19/setup/install/deploy/).
+After you've set up your external storage service, you're ready to [deploy Spinnaker](/docs/setup/install/deploy/).

--- a/content/en/docs/setup/install/storage/azs.md
+++ b/content/en/docs/setup/install/storage/azs.md
@@ -68,4 +68,4 @@ hal config storage edit --type azs
 ## Next steps
 
 After you've set up Azure Storage as your storage service, you're ready to
-[deploy Spinnaker](/docs/v1.19/setup/install/deploy/).
+[deploy Spinnaker](/docs/setup/install/deploy/).

--- a/content/en/docs/setup/install/storage/gcs.md
+++ b/content/en/docs/setup/install/storage/gcs.md
@@ -92,4 +92,4 @@ hal config storage edit --type gcs
 ## Next steps
 
 After you've set up GCS as your external storage service, you're ready to
-[deploy Spinnaker](/docs/v1.19/setup/install/deploy/).
+[deploy Spinnaker](/docs/setup/install/deploy/).

--- a/content/en/docs/setup/install/storage/minio.md
+++ b/content/en/docs/setup/install/storage/minio.md
@@ -74,4 +74,4 @@ hal config storage edit --type s3
 ## Next steps
 
 After you've set up Minio as your external storage service, you're ready to
-[deploy Spinnaker](/docs/v1.19/setup/install/deploy/).
+[deploy Spinnaker](/docs/setup/install/deploy/).

--- a/content/en/docs/setup/install/storage/oracle.md
+++ b/content/en/docs/setup/install/storage/oracle.md
@@ -10,7 +10,7 @@ Using [Oracle Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/
 
 ## Prerequisites
 
-If you have enabled [Oracle Cloud provider](/docs/v1.19/setup/install/providers/oracle/) in Spinnaker, you may use the same region, Tenancy’s OCID, user’s OCID, Compartment's OCID, private key file, and fingerprint to enable Oracle Object Storage. You will need the following to enable Oracle Object Storage in Spinnaker:
+If you have enabled [Oracle Cloud provider](/docs/setup/install/providers/oracle/) in Spinnaker, you may use the same region, Tenancy’s OCID, user’s OCID, Compartment's OCID, private key file, and fingerprint to enable Oracle Object Storage. You will need the following to enable Oracle Object Storage in Spinnaker:
 
 * A user in IAM for the person or system who will be using Spinnaker, and that user must be granted access to Object Storage or in one IAM group with permissions of Object Storage.
 
@@ -94,4 +94,4 @@ For example:
 ## Next steps
 
 After you've set up Oracle Object Storage as your external storage service, you're ready to
-[deploy Spinnaker](/docs/v1.19/setup/install/deploy/).
+[deploy Spinnaker](/docs/setup/install/deploy/).

--- a/content/en/docs/setup/install/storage/redis.md
+++ b/content/en/docs/setup/install/storage/redis.md
@@ -8,7 +8,7 @@ redirect_from: /setup/storage/redis/
 
 {% include
    warning
-   content="We _highly_ recommend relying on [Minio](/docs/v1.19/setup/storage/minio)
+   content="We _highly_ recommend relying on [Minio](/docs/setup/storage/minio)
    instead of Redis if you are looking for a local persistant storage solution
    for Spinnaker. The Redis storage implementation is untested and unsupported
    by anyone in the Spinnaker community."
@@ -42,4 +42,4 @@ hal config storage edit --type redis
 ## Next steps
 
 After you've set up Redis as your external storage service, you're ready to
-[deploy Spinnaker](/docs/v1.19/setup/install/deploy/).
+[deploy Spinnaker](/docs/setup/install/deploy/).

--- a/content/en/docs/setup/install/storage/s3.md
+++ b/content/en/docs/setup/install/storage/s3.md
@@ -10,7 +10,7 @@ Using [S3](https://aws.amazon.com/s3/){:target="\_blank"} as a
 storage source means that Spinnaker will store all of its persistent data in a
 [Bucket](https://aws.amazon.com/s3/details/){:target="\_blank"}.
 
-> :warning: Alternatively, it is possible to use [Minio](/docs/v1.19/setup/storage/minio)
+> :warning: Alternatively, it is possible to use [Minio](/docs/setup/storage/minio)
 > instead of the real S3 if you are looking for a local persistant storage solution
 > for Spinnaker that is compatible with the S3 API.
 
@@ -60,4 +60,4 @@ hal config storage edit --type s3
 ## Next steps
 
 After you've set up S3 as your external storage service, you're ready to
-[deploy Spinnaker](/docs/v1.19/setup/install/deploy/).
+[deploy Spinnaker](/docs/setup/install/deploy/).

--- a/content/en/docs/setup/monitoring/_index.md
+++ b/content/en/docs/setup/monitoring/_index.md
@@ -44,9 +44,9 @@ choice with each Spinnaker service's metrics. To do so, Halyard must be
 provided with third-party specific credentials and/or endpoints explained
 in each system's configuration below:
 
-* [Datadog](/docs/v1.19/setup/monitoring/datadog/)
-* [Prometheus](/docs/v1.19/setup/monitoring/prometheus/#configure-the-spinnaker-monitoring-daemon-for-prometheus)
-* [Stackdriver](/docs/v1.19/setup/monitoring/stackdriver/#configure-the-spinnaker-monitoring-daemon-for-stackdriver)
+* [Datadog](/docs/setup/monitoring/datadog/)
+* [Prometheus](/docs/setup/monitoring/prometheus/#configure-the-spinnaker-monitoring-daemon-for-prometheus)
+* [Stackdriver](/docs/setup/monitoring/stackdriver/#configure-the-spinnaker-monitoring-daemon-for-stackdriver)
 
 Once this is complete and Spinnaker is deployed, you can optionally use the
 `spinnaker-monitoring-third-party` package to deploy pre-configured [Spinnaker

--- a/content/en/docs/setup/other_config/_index.md
+++ b/content/en/docs/setup/other_config/_index.md
@@ -6,10 +6,10 @@ description: >
   A few other things to set up
 ---
 
-You've [installed and configured Spinnaker](/docs/v1.19/setup/install/), but there are still a few other things to set up:
+You've [installed and configured Spinnaker](/docs/setup/install/), but there are still a few other things to set up:
 
-* [Configure your image bakery](/docs/v1.19/setup/bakery/)
-* [Enable security](/docs/v1.19/setup/security/) (auth/auth) for your Spinnaker installation
-* [Set up continuous integration](/docs/v1.19/setup/ci/)
-* [Enable monitoring](/docs/v1.19/setup/monitoring/)
-* And there are a couple of [extra features](/docs/v1.19/setup/features/) that you can enable
+* [Configure your image bakery](/docs/setup/bakery/)
+* [Enable security](/docs/setup/security/) (auth/auth) for your Spinnaker installation
+* [Set up continuous integration](/docs/setup/ci/)
+* [Enable monitoring](/docs/setup/monitoring/)
+* And there are a couple of [extra features](/docs/setup/features/) that you can enable

--- a/content/en/docs/setup/productionize/_index.md
+++ b/content/en/docs/setup/productionize/_index.md
@@ -34,5 +34,5 @@ metrics.
 
 * __Metrics__
 
-  Follow the [monitoring setup instructions](/docs/v1.19/setup/monitoring) to export
+  Follow the [monitoring setup instructions](/docs/setup/monitoring) to export
   Spinnaker's metrics into a metric store of your choice.

--- a/content/en/docs/setup/productionize/caching/_index.md
+++ b/content/en/docs/setup/productionize/caching/_index.md
@@ -5,5 +5,5 @@ weight: 1
 description: 
 ---
 
-* [Configure Redis Usage](/docs/v1.19/setup/productionize/caching/configure-redis-usage/)
-* [Configure Scaling](/docs/v1.19/setup/productionize/caching/configure-redis-usage/)
+* [Configure Redis Usage](/docs/setup/productionize/caching/configure-redis-usage/)
+* [Configure Scaling](/docs/setup/productionize/caching/configure-redis-usage/)

--- a/content/en/docs/setup/productionize/scaling/_index.md
+++ b/content/en/docs/setup/productionize/scaling/_index.md
@@ -5,4 +5,4 @@ weight: 1
 description: 
 ---
 
-* [Horizontally Scale Spinnaker](/docs/v1.19/setup/productionize/scaling/horizontal-scaling/)
+* [Horizontally Scale Spinnaker](/docs/setup/productionize/scaling/horizontal-scaling/)

--- a/content/en/docs/setup/quickstart/_index.md
+++ b/content/en/docs/setup/quickstart/_index.md
@@ -7,7 +7,7 @@ description: >
 ---
 
 
-Here are a few quickstart solutions. These are not meant for production use. To install spinnaker for more than just evaluation, you need a [full install](/docs/v1.19/setup/install/) using Halyard.
+Here are a few quickstart solutions. These are not meant for production use. To install spinnaker for more than just evaluation, you need a [full install](/docs/setup/install/) using Halyard.
 
 * [Amazon Web Services](https://aws.amazon.com/about-aws/whats-new/2016/08/netflix-oss-spinnaker-on-the-aws-cloud-quick-start-reference-deployment/)
 * [Spinnaker for Google Cloud Platform](https://cloud.google.com/docs/ci-cd/spinnaker/spinnaker-for-gcp)

--- a/content/en/docs/setup/quickstart/faq.md
+++ b/content/en/docs/setup/quickstart/faq.md
@@ -41,7 +41,7 @@ infrastructure in whatever accounts it manages, and opening it to the public is
 not a good idea without authentication enabled. With that in mind, there are
 two solutions.
 
-1. Once you enable an [authentication](/docs/v1.19/setup/security/) mechanism, Spinnaker
+1. Once you enable an [authentication](/docs/setup/security/) mechanism, Spinnaker
    will bind the UI and API servers to `0.0.0.0` automatically. This is
    [configurable](/reference/halyard/custom/) if you prefer to bind a specify
    address instead. Regardless, you still need to set the API &
@@ -56,7 +56,7 @@ two solutions.
 
 ## I want to expose the distributed, Kubernetes hosted Spinnaker publicly
 
-There is [a guide](/docs/v1.19/setup/quickstart/halyard-gke-public/) for doing this using
+There is [a guide](/docs/setup/quickstart/halyard-gke-public/) for doing this using
 Google's authentication & domain registrar. If this doesn't match your
 environment, it may still be helpful to read. The key point is, Halyard does
 _not_ touch any of the Kubernetes Service objects once they are created. You
@@ -133,7 +133,7 @@ jittering in the UI as the caches are repopulated.
 
 ## I want to decouple my Halyard configuration from a single machine
 
-Please read [the backup documentation](/docs/v1.19/setup/install/backups/).
+Please read [the backup documentation](/docs/setup/install/backups/).
 
 ## Halyard produces a lot of ugly ANSI escape sequences making it frustrating to automate
 

--- a/content/en/docs/setup/quickstart/halyard-gce.md
+++ b/content/en/docs/setup/quickstart/halyard-gce.md
@@ -8,7 +8,7 @@ sidebar:
 
 
 
- > Note: we recommend that you install Spinnaker following the [standard setup directions](/docs/v1.19/setup/)
+ > Note: we recommend that you install Spinnaker following the [standard setup directions](/docs/setup/)
  rather than using this guide, which is just a set of commands to get Spinnaker up and running on
  GCS and GCE.
 
@@ -273,4 +273,4 @@ Finally, from your local workstation browser, navigate to your [brand new Spinna
 
 ## Next steps
 
-For more information on Halyard and managing Spinnaker, go to the [Setup](/docs/v1.19/setup/install/halyard) section for an overview of how Halyard works, and the [Reference](/reference/halyard/) section for an exhaustive listing of Halyard commands.
+For more information on Halyard and managing Spinnaker, go to the [Setup](/docs/setup/install/halyard) section for an overview of how Halyard works, and the [Reference](/reference/halyard/) section for an exhaustive listing of Halyard commands.

--- a/content/en/docs/setup/quickstart/halyard-gke-deploy-rbac/_index.md
+++ b/content/en/docs/setup/quickstart/halyard-gke-deploy-rbac/_index.md
@@ -8,7 +8,7 @@ description:
 
 
 If you've deployed Spinnaker already using [this
-codelab](/docs/v1.19/setup/quickstart/halyard-gke) you're left with a Spinnaker that can only deploy to the cluster that Spinnaker is deployed in.
+codelab](/docs/setup/quickstart/halyard-gke) you're left with a Spinnaker that can only deploy to the cluster that Spinnaker is deployed in.
 In many cases you want to deploy to clusters in another GCP project that has Kubernetes RBAC enabled.
 
 This codelab shows how to push your containers to a separate, RBAC-enabled cluster in a different GCP project, and how to enable Spinnaker to manipulate deployments in that cluster.
@@ -24,7 +24,7 @@ At the end of this guide you will have:
 
 ## Part 0: Prerequisites
 
-* A GCP project (referred to as $GCP_PROJECT) running a Spinnaker [GKE cluster with Halyard](/docs/v1.19/setup/quickstart/halyard-gke/)
+* A GCP project (referred to as $GCP_PROJECT) running a Spinnaker [GKE cluster with Halyard](/docs/setup/quickstart/halyard-gke/)
 * Another K8s cluster (referred to as $K8_TEST) running with Kubernetes version > 1.6 on another GCP project ($GCP_TEST)
 
 ## Part 1: Configure gcloud

--- a/content/en/docs/setup/quickstart/halyard-gke-public/_index.md
+++ b/content/en/docs/setup/quickstart/halyard-gke-public/_index.md
@@ -8,7 +8,7 @@ description:
 
 
 If you've deployed Spinnaker already using [this
-codelab](/docs/v1.19/setup/quickstart/halyard-gke) you're left with a Spinnaker that's
+codelab](/docs/setup/quickstart/halyard-gke) you're left with a Spinnaker that's
 accessible only with `hal deploy connect`. This is unwieldy, making Spinnaker
 difficult for other users in your organization to access.
 
@@ -31,7 +31,7 @@ You need a [GAFW domain](https://admin.google.com) (referred to as `$DOMAIN`
 for the remainder of this tutorial).
 
 You need a running Spinnaker cluster in GKE. If you don't have one, please go
-through [this codelab](/docs/v1.19/setup/quickstart/halyard-gke).
+through [this codelab](/docs/setup/quickstart/halyard-gke).
 
 ## Part 1: Configuring authentication
 

--- a/content/en/docs/setup/quickstart/halyard-gke/_index.md
+++ b/content/en/docs/setup/quickstart/halyard-gke/_index.md
@@ -5,11 +5,11 @@ weight: 1
 description: 
 ---
 
-> Note: we recommend that you install Spinnaker following the [standard setup directions](/docs/v1.19/setup/)
+> Note: we recommend that you install Spinnaker following the [standard setup directions](/docs/setup/)
  rather than using this guide, which is just a set of commands to get Spinnaker up and running on
  GCS and GKE.
 
-In this guide, you will learn the basics of [Halyard](/docs/v1.19/setup/install/halyard/), Spinnaker's tool for managing your Spinnaker instance.
+In this guide, you will learn the basics of [Halyard](/docs/setup/install/halyard/), Spinnaker's tool for managing your Spinnaker instance.
 
 ## Overview
 
@@ -260,7 +260,7 @@ authorization if necessary. Then re-run `hal deploy apply`.
 > :point_right: Halyard will warn you that you have deployed Spinnaker remotely
 > without configuring an authentication mechanism. This is OK, but cumbersome,
 > since we can connect via SSH tunnels. If you want to configure
-> authentication, read more in the [security documentation](/docs/v1.19/setup/security).
+> authentication, read more in the [security documentation](/docs/setup/security).
 
 Now, to connect to Spinnaker, run:
 
@@ -273,4 +273,4 @@ Finally, from your local workstation browser, navigate to your [brand new Spinna
 
 ## Next steps
 
-For more information on halyard and managing Spinnaker, go to the [Setup](/docs/v1.19/setup/install/halyard) section for an overview of how halyard works, and the [Reference](/reference/halyard/) section for an exhaustive listing of halyard commands.
+For more information on halyard and managing Spinnaker, go to the [Setup](/docs/setup/install/halyard) section for an overview of how halyard works, and the [Reference](/reference/halyard/) section for an exhaustive listing of halyard commands.

--- a/content/en/docs/setup/quickstart/halyard.md
+++ b/content/en/docs/setup/quickstart/halyard.md
@@ -5,13 +5,13 @@ sidebar:
   nav: setup
 ---
 
- > Note: we recommend that you install Spinnaker following the [standard setup directions](/docs/v1.19/setup/) rather than the guides listed here.
+ > Note: we recommend that you install Spinnaker following the [standard setup directions](/docs/setup/) rather than the guides listed here.
 
-[Demo installs](/docs/v1.19/setup/quickstart/) are self-contained simple Spinnaker installations that don't require Halyard. But you can do a fairly quick <em>full</em> install using Halyard, and here
+[Demo installs](/docs/setup/quickstart/) are self-contained simple Spinnaker installations that don't require Halyard. But you can do a fairly quick <em>full</em> install using Halyard, and here
 are a few configurations to get you started. If your environment matches one of these, click through for instructions.
 
-* [Halyard on Google Kubernetes Engine Quickstart](/docs/v1.19/setup/quickstart/halyard-gke/)
-* [Halyard on Google Compute Engine Quickstart](/docs/v1.19/setup/quickstart/halyard-gce/)
+* [Halyard on Google Kubernetes Engine Quickstart](/docs/setup/quickstart/halyard-gke/)
+* [Halyard on Google Compute Engine Quickstart](/docs/setup/quickstart/halyard-gce/)
 * [Public Spinnaker on Google Kubernetes
-  Engine](/docs/v1.19/setup/quickstart/halyard-gke-public/)
-* [Deploy to RBAC enabled cluster on Google Kubernetes Engine](/docs/v1.19/setup/quickstart/halyard-gke-deploy-rbac)
+  Engine](/docs/setup/quickstart/halyard-gke-public/)
+* [Deploy to RBAC enabled cluster on Google Kubernetes Engine](/docs/setup/quickstart/halyard-gke-deploy-rbac)

--- a/content/en/docs/setup/security/authentication/index.md
+++ b/content/en/docs/setup/security/authentication/index.md
@@ -72,6 +72,6 @@ A common issue with Incognito windows is that they _all share the same cookie ja
 
 ## Next steps
 
-Set up [Authorization](/docs/v1.19/setup/security/authorization/).
+Set up [Authorization](/docs/setup/security/authorization/).
 
-Learn how to configure Spinnaker to communicate over [SSL](/docs/v1.19/setup/security/ssl).
+Learn how to configure Spinnaker to communicate over [SSL](/docs/setup/security/ssl).

--- a/content/en/docs/setup/security/authentication/ldap/index.md
+++ b/content/en/docs/setup/security/authentication/ldap/index.md
@@ -137,13 +137,13 @@ hal config security authn ldap edit --manager-password
 
 ## Next steps
 
-Now that you've authenticated the user, proceed to setting up their [authorization](/docs/v1.19/setup/security/authorization/).
+Now that you've authenticated the user, proceed to setting up their [authorization](/docs/setup/security/authorization/).
 
 ## Troubleshooting
 
 * Review the general [authentication workflow](/reference/architecture/authz_authn/authentication//#workflow).
 
-* Use an [Incognito window](/docs/v1.19/setup/security/authentication#incognito-mode). Close all Incognito windows between attempts.
+* Use an [Incognito window](/docs/setup/security/authentication#incognito-mode). Close all Incognito windows between attempts.
 
 * I'm getting the "Bad Credentials" exception mentioned above, but my username and password is
 correct!

--- a/content/en/docs/setup/security/authentication/oauth/index.md
+++ b/content/en/docs/setup/security/authentication/oauth/index.md
@@ -36,7 +36,7 @@ During the OAuth [workflow](/reference/architecture/authz_authn/authentication/#
 guess on how to assemble a URI to
 itself, called the *redirect URI*. Sometimes this guess is wrong when Spinnaker is deployed
 in concert with other networking components, such as an SSL-terminating load balancer, or in the
-case of the [Quickstart](/docs/v1.19/setup/quickstart) images, a fronting Apache instance.
+case of the [Quickstart](/docs/setup/quickstart) images, a fronting Apache instance.
 
 You can manually set the redirect URI at the `security.authn.oauth2.client.preEstablishedRedirectUri`
 field
@@ -120,13 +120,13 @@ hal config security authn oauth2 edit \
 
 ## Next steps
 
-Now that you've authenticated the user, proceed to setting up their [authorization](/docs/v1.19/setup/security/authorization/).
+Now that you've authenticated the user, proceed to setting up their [authorization](/docs/setup/security/authorization/).
 
 ## Troubleshooting
 
 * Review the general [authentication workflow](/reference/architecture/authz_authn/authentication/#workflow).
 
-* Use an [incognito window](/docs/v1.19/setup/security/authentication#incognito-mode).
+* Use an [incognito window](/docs/setup/security/authentication#incognito-mode).
 
 * I'm getting an `Error: redirect_uri_mismatch` from my OAuth provider.
 

--- a/content/en/docs/setup/security/authentication/saml/index.md
+++ b/content/en/docs/setup/security/authentication/saml/index.md
@@ -98,14 +98,14 @@ may look something like this:
 During the SAML [workflow](/reference/architecture/authz_authn/authentication/#workflow), Gate makes an intelligent 
 guess on how to assemble a URI to itself, called the _Assertion Consumer Service URL_. Sometimes this guess is wrong 
 when Spinnaker is deployed in concert with other networking components, such as an SSL-terminating load balancer, or 
-in the case of the [Quickstart](/docs/v1.19/setup/quickstart) images, a fronting Apache instance.  
+in the case of the [Quickstart](/docs/setup/quickstart) images, a fronting Apache instance.  
 
 To override the values to assemble the URL, use the following `hal` command:
 ```bash
 hal config security authn saml edit --service-address-url https://my-real-gate-address.com:8084
 ```
 
-Please check on the [SSL Documentation](/docs/v1.19/setup/security/ssl) for more information.
+Please check on the [SSL Documentation](/docs/setup/security/ssl) for more information.
 
 > For the Quickstart images, append `/gate` to the `--service-address-url`. All other configurations
 can omit this setting.
@@ -168,11 +168,11 @@ endpoint.
 
 ## Next steps
 
-Now that you've authenticated the user, proceed to setting up their [authorization](/docs/v1.19/setup/security/authorization/).
+Now that you've authenticated the user, proceed to setting up their [authorization](/docs/setup/security/authorization/).
 
 ## Troubleshooting
 
-* Review the general [authentication guide](/docs/v1.19/setup/security/authentication).
+* Review the general [authentication guide](/docs/setup/security/authentication).
 * Review the authentication [reference guide](/reference/architecture/authz_authn/authentication).
 
-* Use an [incognito window](/docs/v1.19/setup/security/authentication#incognito-mode).
+* Use an [incognito window](/docs/setup/security/authentication#incognito-mode).

--- a/content/en/docs/setup/security/authentication/x509/index.md
+++ b/content/en/docs/setup/security/authentication/x509/index.md
@@ -13,7 +13,7 @@ is generally easier than dynamically obtaining an OAuth Bearer token or SAML ass
 
 ## Certificates
 
-If you followed the [SSL](/docs/v1.19/setup/security/ssl) guide, you may already have generated a **certificate
+If you followed the [SSL](/docs/setup/security/ssl) guide, you may already have generated a **certificate
 authority**
 (CA). Using this CA, we can generate a client certificate using `openssl`.
 
@@ -160,12 +160,12 @@ passing between Deck, Gate, and a third-party identity provider. Connections are
 
 ## Next steps
 
-Now that you've authenticated the user, proceed to setting up their [authorization](/docs/v1.19/setup/security/authorization/).
+Now that you've authenticated the user, proceed to setting up their [authorization](/docs/setup/security/authorization/).
 
 ## Troubleshooting
 
-* Review the general [authentication guide](/docs/v1.19/setup/security/authentication).
+* Review the general [authentication guide](/docs/setup/security/authentication).
 * Review the authentication [reference guide](/reference/architecture/authz_authn/authentication).
 
 
-* Use an [incognito window](/docs/v1.19/setup/security/authentication#incognito-mode).
+* Use an [incognito window](/docs/setup/security/authentication#incognito-mode).

--- a/content/en/docs/setup/security/authorization/_index.md
+++ b/content/en/docs/setup/security/authorization/_index.md
@@ -35,7 +35,7 @@ define who is allowed to access it, it is considered unrestricted.  This means:
    instance names and counts within server groups.
 
 1)  Every permission in Spinnaker is granted to a role. Individual users cannot be granted permissions. You also grant
- [Super admin](/docs/v1.19/setup/security/admin/) access to a role. You may see discussions of users in Fiat’s implementation but
+ [Super admin](/docs/setup/security/admin/) access to a role. You may see discussions of users in Fiat’s implementation but
   it’s just an optimization in the storage to not recompute user → roles → permissions.
 
 1)  Account and application access control can be confusing unless you understand the core

--- a/content/en/docs/setup/security/authorization/google-groups/index.md
+++ b/content/en/docs/setup/security/authorization/google-groups/index.md
@@ -50,7 +50,7 @@ create a service account that will access the G Suite Directory API.
 
 ## Configure with Halyard
 
-1. Make sure you've configured roles for accounts, as described [here](/docs/v1.19/setup/security/authorization/#accounts). Each role included in the command must match the name of a group
+1. Make sure you've configured roles for accounts, as described [here](/docs/setup/security/authorization/#accounts). Each role included in the command must match the name of a group
 in the organization.
 
 1. With the authorized service account's credentials in hand, use Halyard to configure Fiat:

--- a/content/en/docs/setup/security/authorization/pipeline-permissions/index.md
+++ b/content/en/docs/setup/security/authorization/pipeline-permissions/index.md
@@ -7,7 +7,7 @@ description:
 
 Pipeline permissions enable automatically triggered pipelines to modify
 resources in protected accounts and applications. They are an alternative
-to manually managing [Fiat Service Accounts](/docs/v1.19/setup/security/authorization/service-accounts/).
+to manually managing [Fiat Service Accounts](/docs/setup/security/authorization/service-accounts/).
 
 Without pipeline permissions, a Spinnaker operator first has to create a
 Fiat Service account with the correct permissions. A user can then specify the
@@ -40,7 +40,7 @@ is added in the pipeline configuration page in the UI. You can add any of the
 roles that you currently have. Once you add a role to the pipeline, only users
 who have _all of the specified roles_ can edit or execute the pipeline.
 This is similar to the behavior of
-[Fiat service accounts](/docs/v1.19/setup/security/authorization/service-accounts#service-account-roles).
+[Fiat service accounts](/docs/setup/security/authorization/service-accounts#service-account-roles).
 
 ![permissions selector from pipeline config in Deck](permissions-selector.png)
 
@@ -57,7 +57,7 @@ from your trigger, or enable the automatic migration (see next section).
 ### Automatic migration
 
 Front50 can automatically migrate all pipelines from using [Fiat Service
-Accounts](/docs/v1.19/setup/security/authorization/service-accounts/) to use Pipeline Permissions and managed service
+Accounts](/docs/setup/security/authorization/service-accounts/) to use Pipeline Permissions and managed service
 accounts. The migrator is disabled by default, and can be enabled by adding the
 following flag to `front50-local.yml`:
 

--- a/content/en/docs/setup/security/ssl.md
+++ b/content/en/docs/setup/security/ssl.md
@@ -31,14 +31,14 @@ you implement at least a temporary SSL solution **first**.
 A common practice is to offload SSL-related bits to outside of the server in
 question. This is fully supported in Spinnaker, but it does affect the
 authentication configuration slightly. See your [authentication
-method](/docs/v1.19/setup/security/authentication/) for specifics.
+method](/docs/setup/security/authentication/) for specifics.
 
-![SSL terminated at load balancer](/docs/v1.19/setup/security/authentication/network-arch/lb-ssl-termination.png)
+![SSL terminated at load balancer](/docs/setup/security/authentication/network-arch/lb-ssl-termination.png)
 
 During certain authentication workflows, Gate makes an intelligent guess on how to assemble a URI to
 itself, called the **`redirect_uri`**. Sometimes this guess is wrong when Spinnaker is deployed
 in concert with other networking components, such as an SSL-terminating load balancer, or in the
-case of the [Quickstart](/docs/v1.19/setup/quickstart) images, a fronting Apache instance.
+case of the [Quickstart](/docs/setup/quickstart) images, a fronting Apache instance.
 
 To manually set the `redirect_uri` for Gate, use the following `hal` command:
 
@@ -86,7 +86,7 @@ Terminating SSL within the Gate server is the de-facto way to enable SSL for
 Spinnaker. This works with or without a load balancer proxying traffic to this
 instance.  
 
-![SSL terminated at server through load balancer](/docs/v1.19/setup/security/authentication/network-arch/server-ssl-termination.png)
+![SSL terminated at server through load balancer](/docs/setup/security/authentication/network-arch/server-ssl-termination.png)
 
 #### 1. Generate key and self-signed certificate
 
@@ -406,7 +406,7 @@ new trust/key store by default.
 
 Choose an authentication method:
 
-* [OAuth 2.0](/docs/v1.19/setup/security/authentication/oauth/)
-* [SAML](/docs/v1.19/setup/security/authentication/saml/)
-* [LDAP](/docs/v1.19/setup/security/authentication/ldap/)
-* [X.509](/docs/v1.19/setup/security/authentication/x509/)
+* [OAuth 2.0](/docs/setup/security/authentication/oauth/)
+* [SAML](/docs/setup/security/authentication/saml/)
+* [LDAP](/docs/setup/security/authentication/ldap/)
+* [X.509](/docs/setup/security/authentication/x509/)

--- a/content/en/docs/setup/triggers/_index.md
+++ b/content/en/docs/setup/triggers/_index.md
@@ -5,6 +5,6 @@ weight: 1
 description: 
 ---
 
-* [Google Pub/Sub](/docs/v1.19/setup/triggers/google/)
-* [Amazon Pub/Sub](/docs/v1.19/setup/triggers/amazon/)
-* [GitHub Webhook](/docs/v1.19/setup/triggers/github/)
+* [Google Pub/Sub](/docs/setup/triggers/google/)
+* [Amazon Pub/Sub](/docs/setup/triggers/amazon/)
+* [GitHub Webhook](/docs/setup/triggers/github/)

--- a/content/en/docs/setup/triggers/github/_index.md
+++ b/content/en/docs/setup/triggers/github/_index.md
@@ -13,7 +13,7 @@ configure webhook push events to send to Spinnaker from a single GitHub reposito
 
 * You need Spinnaker's API running on an endpoint that is publicly reachable.
   Ideally this means that you've configured
-  [authentication](/docs/v1.19/setup/security/authentication). This is required to allow
+  [authentication](/docs/setup/security/authentication). This is required to allow
   GitHub's webhooks to reach Spinnaker.
 
   If you're unsure of what your Spinnaker API endpoint is, check the value of

--- a/netlify.toml
+++ b/netlify.toml
@@ -49,3 +49,4 @@ HUGO_ENABLEGITINFO = "true"
   to = "/docs/reference/:splat"
   status = 301
   force = false
+  

--- a/netlify.toml
+++ b/netlify.toml
@@ -31,3 +31,21 @@ HUGO_VERSION = "0.70.0"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"
+
+[[redirects]]
+  from = "/setup/*"
+  to = "/docs/setup/:splat"
+  status = 301
+  force = false
+
+[[redirects]]
+  from = "/guides/*"
+  to = "/docs/guides/:splat"
+  status = 301
+  force = false
+
+[[redirects]]
+  from = "/reference/*"
+  to = "/docs/reference/:splat"
+  status = 301
+  force = false


### PR DESCRIPTION
For example, redirect `/concepts/` to `/docs/concepts`