### PR TITLE
docs(migration): backend changes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -32,11 +32,11 @@ pygmentsStyle = "tango"
 blog = "/:section/:year/:month/:day/:slug/"
 
 ## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
-[blackfriday]
-plainIDAnchors = true
-hrefTargetBlank = true
-angledQuotes = false
-latexDashes = true
+# [blackfriday]
+# plainIDAnchors = true
+# hrefTargetBlank = true
+# angledQuotes = false
+# latexDashes = true
 
 # Image processing configuration.
 [imaging]
@@ -68,10 +68,35 @@ weight = 1
 # time_format_blog = "02.01.2006"
 
 [markup]
+defaultMarkdownHandler = "goldmark"
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
-
+      definitionList = true
+            footnote = true
+            linkify = true
+            strikethrough = true
+            table = true
+            taskList = true
+            typographer = true
+          [markup.goldmark.parser]
+            attribute = true
+            autoHeadingID = true
+            autoHeadingIDType = "github"
+        [markup.highlight]
+          codeFences = true
+          guessSyntax = false
+          hl_Lines = ""
+          lineNoStart = 1
+          lineNos = false
+          lineNumbersInTable = true
+          noClasses = true
+          style = "monokai"
+          tabWidth = 4
+        [markup.tableOfContents]
+          endLevel = 3
+          ordered = false
+          startLevel = 2
 # Everything below this are Site Params
 [params]
 copyright = 'Copyright © 2020 The Linux Foundation®. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. Linux is a registered trademark of Linus Torvalds.'

--- a/content/en/docs/community/contributing/build-statuses/index.md
+++ b/content/en/docs/community/contributing/build-statuses/index.md
@@ -57,7 +57,7 @@ branches:
   {%- else -%}
     {%- capture job -%}Flow_BuildAndValidate_{{branch | remove: "release-" | replace: ".", "_"}}{%- endcapture -%}
   {%- endif -%}
-* [![{{branch}} Build Status](https://builds.spinnaker.io/buildStatus/icon?job={{job}}&subject={{subject}}){:style="height: 25px"}](https://builds.spinnaker.io/job/{{job}}/){:target="\_blank"}
+* [![{{branch}} Build Status](https://builds.spinnaker.io/buildStatus/icon?job={{job}}&subject={{subject}}){:style="height: 25px"}](https://builds.spinnaker.io/job/{{job}}/)
 {% endfor %}
 
 
@@ -76,7 +76,7 @@ Service | Branch | Status
     {%- capture githubStatusImg -%}https://github.com/spinnaker/{{svc}}/workflows/Branch%20Build/badge.svg?branch={{branch}}{%- endcapture -%}
     {%- capture githubLink -%}https://github.com/spinnaker/{{svc}}/actions?query=workflow%3A%22Branch+Build%22+branch%3A{{branch}}{%- endcapture -%}
 
-    {{svcCol}} | `{{branch}}` | [![{{altTxt}}]({{githubStatusImg}}){:style="height: 25px"}]({{githubLink}}){:target="\_blank"}
+    {{svcCol}} | `{{branch}}` | [![{{altTxt}}]({{githubStatusImg}}){:style="height: 25px"}]({{githubLink}})
 {% endfor %}{% endfor %}
 
 
@@ -87,5 +87,5 @@ Service | Branch | Status
   {% capture githubStatusImg %}https://github.com/spinnaker/{{svc}}/workflows/Branch%20Build/badge.svg{% endcapture %}
   {% capture githubLink %}https://github.com/spinnaker/{{svc}}/actions?query=workflow%3A%22Branch+Build%22+branch%3Amaster{% endcapture %}
 
-  * {{svc | capitalize }} [![{{altTxt}}]({{githubStatusImg}}){:style="height: 25px"}]({{githubLink}}){:target="\_blank"}
+  * {{svc | capitalize }} [![{{altTxt}}]({{githubStatusImg}}){:style="height: 25px"}]({{githubLink}})
 {% endfor %}

--- a/content/en/docs/community/contributing/docs/index.md
+++ b/content/en/docs/community/contributing/docs/index.md
@@ -7,7 +7,7 @@ description:
 
 Bugs affecting more than one service commonly surface only when the whole system is running. Our continuous integration system builds and runs a suite of integration tests against Spinnaker nightly on real cloud provider infrastructure to detect these bugs.
 
-> **Access the CI system here**: [https://builds.spinnaker.io](https://builds.spinnaker.io){:target="\_blank"}
+> **Access the CI system here**: [https://builds.spinnaker.io](https://builds.spinnaker.io)
 >
 > Viewers must be a member of the `build-cops` GitHub Team.
 
@@ -17,24 +17,24 @@ The **build cop** responsibilities include:
 
 * Triage integration test failures on `master` and the 3 most recent release branches
 * [Clean up](#cleaning-orphaned-resources) orphaned resources across target cloud providers
-* Route [new GitHub issues](https://github.com/spinnaker/spinnaker/issues){:target="\_blank"} to the appropriate SIG
+* Route [new GitHub issues](https://github.com/spinnaker/spinnaker/issues) to the appropriate SIG
   (applying GitHub labels as appropriate). You can find the full list of SIGs in the
-  [governance repo](https://github.com/spinnaker/governance/blob/master/sig-index.md){:target="\_blank"}
-* Observe any systemic problems raised in the [#general](https://spinnakerteam.slack.com/messages/general/){:target="\_blank"}
-  and [#dev](https://spinnakerteam.slack.com/messages/dev/){:target="\_blank"} Slack channels
-* Log observations and corrective actions taken in the [rotation log](https://docs.google.com/document/d/1T0kifZ0C7zSIKOy2McKfmDnwvmRuU5Z3t81Tly6kH1M/edit#){:target="\_blank"}
+  [governance repo](https://github.com/spinnaker/governance/blob/master/sig-index.md)
+* Observe any systemic problems raised in the [#general](https://spinnakerteam.slack.com/messages/general/)
+  and [#dev](https://spinnakerteam.slack.com/messages/dev/) Slack channels
+* Log observations and corrective actions taken in the [rotation log](https://docs.google.com/document/d/1T0kifZ0C7zSIKOy2McKfmDnwvmRuU5Z3t81Tly6kH1M/edit#)
 
 ## Process Structure
 
 The CI system comprises both _jobs_, which do a specific task, and _flows_, which invoke a series of jobs.
 
-[`Flow_BuildAndValidate`](https://builds.spinnaker.io/job/Flow_BuildAndValidate/){:target="\_blank"} is the primary entry point for the `master` branch flow.
+[`Flow_BuildAndValidate`](https://builds.spinnaker.io/job/Flow_BuildAndValidate/) is the primary entry point for the `master` branch flow.
 
 `Flow_BuildAndValidate_<version>` is the the entry point for the respective top-level release. It is a copy of the primary `Flow_BuildAndValidate` when that release was cut. Top-level release flows work off their respective `release-1.ABC.x` branches.
 
 As its name implies, `Flow_BuildAndValidate` builds and tests the whole Spinnaker system. It follows this general process:
 
-### 1. [Build_PrimaryArtifacts](https://builds.spinnaker.io/job/Build_PrimaryArtifacts/){:target="\_blank"}
+### 1. [Build_PrimaryArtifacts](https://builds.spinnaker.io/job/Build_PrimaryArtifacts/)
 
 1. `git checkout` all services
 1. Constructs a BOM from the most recent commit on the target branch
@@ -48,11 +48,11 @@ As its name implies, `Flow_BuildAndValidate` builds and tests the whole Spinnake
   * _With a fixed tag:_ `<branchName>-<timestamp>` (e.g. `master-20191213154039`)
 1. Publishes the [changelog](https://gist.github.com/spinnaker-release/4f8cd09490870ae9ebf78be3be1763ee)
 
-### 2. [Validate_BomAndReportMultiPlatform](https://builds.spinnaker.io/job/Validate_BomAndReportMultiPlatform/){:target="\_blank"}
+### 2. [Validate_BomAndReportMultiPlatform](https://builds.spinnaker.io/job/Validate_BomAndReportMultiPlatform/)
 
 For uninteresting reasons, this job must wrap the following `ValidateBomMultiPlatform` in order to aggregate its results.
 
-### 3. [ValidateBomMultiPlatform](https://builds.spinnaker.io/job/Validate_BomMultiPlatform/){:target="\_blank"}
+### 3. [ValidateBomMultiPlatform](https://builds.spinnaker.io/job/Validate_BomMultiPlatform/)
 
 This "Multi-configuration project" specifies the same test(s) to run across different environments. This confirms
 Spinnaker works whether deployed as a single VM or in a Kubernetes cluster, for instance.
@@ -60,25 +60,25 @@ Spinnaker works whether deployed as a single VM or in a Kubernetes cluster, for 
 1. Starts Halyard in a new VM
 1. Connects to this instance and executes a series of `hal config` steps, including account setup for the managed cloud provider(s).
 1. Deploys the configuration with `hal deploy apply`.
-1. Invokes [`citest`](https://github.com/google/citest){:target="\_blank"} integration tests against the new Spinnaker instance.
+1. Invokes [`citest`](https://github.com/google/citest) integration tests against the new Spinnaker instance.
     * `citest` invokes a command to Spinnaker, and then uses the underlying cloud provider's CLI to confirm the expected changes were made. For example, using `gcloud` to confirm a GCE server group was created or deleted.
 
 ## Cleaning Orphaned Resources
 
 Occasionally, integration tests fail in a way that is either undesirable or difficult to automatically clean up. Build cops should periodically ensure these orphaned resources are deleted from the following locations:
 
-* [`spinnaker-community` GCP project](https://console.cloud.google.com/home/dashboard?organizationId=912934373776&project=spinnaker-community){:target="\_blank"}
-  * [Instance Groups](https://console.cloud.google.com/compute/instanceGroups/list?organizationId=912934373776&project=spinnaker-community&instanceGroupsTablesize=50&instanceGroupsTablequery=%255B%257B_22k_22_3A_22name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22gcp*_5C_22_22%257D%255D){:target="\_blank"} named `gcp<testName>-*`
-  * [VMs](https://console.cloud.google.com/compute/instances?organizationId=912934373776&project=spinnaker-community&instancessize=50&instancesquery=%255B%257B_22k_22_3A_22name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22jenkins-validate-bom*_5C_22_22%257D%255D){:target="\_blank"} named `jenkins-validate-bom-*`
-  * [Load balancers](https://console.cloud.google.com/net-services/loadbalancing/loadBalancers/list?project=spinnaker-community&organizationId=912934373776&filter=%255B%257B_22k_22_3A_22Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22gcp*_5C_22_22%257D%255D){:target="\_blank"} named `gcp<testName>-*`
-  * [Managed certificates](https://console.cloud.google.com/net-services/loadbalancing/advanced/sslCertificates/list?project=spinnaker-community&organizationId=912934373776&sslCertificateTablesize=50&sslCertificateTablequery=%255B%257B_22k_22_3A_22domain_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22localhost_5C_22_22%257D%255D){:target="\_blank"} that are _**not**_ `builds.spinnaker.io` (!)
+* [`spinnaker-community` GCP project](https://console.cloud.google.com/home/dashboard?organizationId=912934373776&project=spinnaker-community)
+  * [Instance Groups](https://console.cloud.google.com/compute/instanceGroups/list?organizationId=912934373776&project=spinnaker-community&instanceGroupsTablesize=50&instanceGroupsTablequery=%255B%257B_22k_22_3A_22name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22gcp*_5C_22_22%257D%255D) named `gcp<testName>-*`
+  * [VMs](https://console.cloud.google.com/compute/instances?organizationId=912934373776&project=spinnaker-community&instancessize=50&instancesquery=%255B%257B_22k_22_3A_22name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22jenkins-validate-bom*_5C_22_22%257D%255D) named `jenkins-validate-bom-*`
+  * [Load balancers](https://console.cloud.google.com/net-services/loadbalancing/loadBalancers/list?project=spinnaker-community&organizationId=912934373776&filter=%255B%257B_22k_22_3A_22Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22gcp*_5C_22_22%257D%255D) named `gcp<testName>-*`
+  * [Managed certificates](https://console.cloud.google.com/net-services/loadbalancing/advanced/sslCertificates/list?project=spinnaker-community&organizationId=912934373776&sslCertificateTablesize=50&sslCertificateTablequery=%255B%257B_22k_22_3A_22domain_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22localhost_5C_22_22%257D%255D) that are _**not**_ `builds.spinnaker.io` (!)
 
 ## Deleting Obsolete Artifacts
 
 The following jobs assist in removing old artifacts created during the build process:
-* [Admin_DailyJanitor](https://builds.spinnaker.io/view/5%20Admin/job/Admin_DailyJanitor/){:target="\_blank"}
-* [Admin_AuditBoms](https://builds.spinnaker.io/view/5%20Admin/job/Admin_AuditBoms/){:target="\_blank"}
-* [Admin_DeleteObsoleteArtifacts](https://builds.spinnaker.io/view/5%20Admin/job/Admin_DeleteObsoleteArtifacts/){:target="\_blank"}
+* [Admin_DailyJanitor](https://builds.spinnaker.io/view/5%20Admin/job/Admin_DailyJanitor/)
+* [Admin_AuditBoms](https://builds.spinnaker.io/view/5%20Admin/job/Admin_AuditBoms/)
+* [Admin_DeleteObsoleteArtifacts](https://builds.spinnaker.io/view/5%20Admin/job/Admin_DeleteObsoleteArtifacts/)
 
 ## Troubleshooting Playbook
 

--- a/content/en/docs/community/contributing/nightly-builds/index.md
+++ b/content/en/docs/community/contributing/nightly-builds/index.md
@@ -7,7 +7,7 @@ description:
 
 Bugs affecting more than one service commonly surface only when the whole system is running. Our continuous integration system builds and runs a suite of integration tests against Spinnaker nightly on real cloud provider infrastructure to detect these bugs.
 
-> **Access the CI system here**: [https://builds.spinnaker.io](https://builds.spinnaker.io){:target="\_blank"}
+> **Access the CI system here**: [https://builds.spinnaker.io](https://builds.spinnaker.io)
 >
 > Viewers must be a member of the `build-cops` GitHub Team.
 
@@ -17,24 +17,24 @@ The **build cop** responsibilities include:
 
 * Triage integration test failures on `master` and the 3 most recent release branches
 * [Clean up](#cleaning-orphaned-resources) orphaned resources across target cloud providers
-* Route [new GitHub issues](https://github.com/spinnaker/spinnaker/issues){:target="\_blank"} to the appropriate SIG
+* Route [new GitHub issues](https://github.com/spinnaker/spinnaker/issues) to the appropriate SIG
   (applying GitHub labels as appropriate). You can find the full list of SIGs in the
-  [governance repo](https://github.com/spinnaker/governance/blob/master/sig-index.md){:target="\_blank"}
-* Observe any systemic problems raised in the [#general](https://spinnakerteam.slack.com/messages/general/){:target="\_blank"}
-  and [#dev](https://spinnakerteam.slack.com/messages/dev/){:target="\_blank"} Slack channels
-* Log observations and corrective actions taken in the [rotation log](https://docs.google.com/document/d/1T0kifZ0C7zSIKOy2McKfmDnwvmRuU5Z3t81Tly6kH1M/edit#){:target="\_blank"}
+  [governance repo](https://github.com/spinnaker/governance/blob/master/sig-index.md)
+* Observe any systemic problems raised in the [#general](https://spinnakerteam.slack.com/messages/general/)
+  and [#dev](https://spinnakerteam.slack.com/messages/dev/) Slack channels
+* Log observations and corrective actions taken in the [rotation log](https://docs.google.com/document/d/1T0kifZ0C7zSIKOy2McKfmDnwvmRuU5Z3t81Tly6kH1M/edit#)
 
 ## Process Structure
 
 The CI system comprises both _jobs_, which do a specific task, and _flows_, which invoke a series of jobs.
 
-[`Flow_BuildAndValidate`](https://builds.spinnaker.io/job/Flow_BuildAndValidate/){:target="\_blank"} is the primary entry point for the `master` branch flow.
+[`Flow_BuildAndValidate`](https://builds.spinnaker.io/job/Flow_BuildAndValidate/) is the primary entry point for the `master` branch flow.
 
 `Flow_BuildAndValidate_<version>` is the the entry point for the respective top-level release. It is a copy of the primary `Flow_BuildAndValidate` when that release was cut. Top-level release flows work off their respective `release-1.ABC.x` branches.
 
 As its name implies, `Flow_BuildAndValidate` builds and tests the whole Spinnaker system. It follows this general process:
 
-### 1. [Build_PrimaryArtifacts](https://builds.spinnaker.io/job/Build_PrimaryArtifacts/){:target="\_blank"}
+### 1. [Build_PrimaryArtifacts](https://builds.spinnaker.io/job/Build_PrimaryArtifacts/)
 
 1. `git checkout` all services
 1. Constructs a BOM from the most recent commit on the target branch
@@ -48,11 +48,11 @@ As its name implies, `Flow_BuildAndValidate` builds and tests the whole Spinnake
   * _With a fixed tag:_ `<branchName>-<timestamp>` (e.g. `master-20191213154039`)
 1. Publishes the [changelog](https://gist.github.com/spinnaker-release/4f8cd09490870ae9ebf78be3be1763ee)
 
-### 2. [Validate_BomAndReportMultiPlatform](https://builds.spinnaker.io/job/Validate_BomAndReportMultiPlatform/){:target="\_blank"}
+### 2. [Validate_BomAndReportMultiPlatform](https://builds.spinnaker.io/job/Validate_BomAndReportMultiPlatform/)
 
 For uninteresting reasons, this job must wrap the following `ValidateBomMultiPlatform` in order to aggregate its results.
 
-### 3. [ValidateBomMultiPlatform](https://builds.spinnaker.io/job/Validate_BomMultiPlatform/){:target="\_blank"}
+### 3. [ValidateBomMultiPlatform](https://builds.spinnaker.io/job/Validate_BomMultiPlatform/)
 
 This "Multi-configuration project" specifies the same test(s) to run across different environments. This confirms
 Spinnaker works whether deployed as a single VM or in a Kubernetes cluster, for instance.
@@ -60,25 +60,25 @@ Spinnaker works whether deployed as a single VM or in a Kubernetes cluster, for 
 1. Starts Halyard in a new VM
 1. Connects to this instance and executes a series of `hal config` steps, including account setup for the managed cloud provider(s).
 1. Deploys the configuration with `hal deploy apply`.
-1. Invokes [`citest`](https://github.com/google/citest){:target="\_blank"} integration tests against the new Spinnaker instance.
+1. Invokes [`citest`](https://github.com/google/citest) integration tests against the new Spinnaker instance.
     * `citest` invokes a command to Spinnaker, and then uses the underlying cloud provider's CLI to confirm the expected changes were made. For example, using `gcloud` to confirm a GCE server group was created or deleted.
 
 ## Cleaning Orphaned Resources
 
 Occasionally, integration tests fail in a way that is either undesirable or difficult to automatically clean up. Build cops should periodically ensure these orphaned resources are deleted from the following locations:
 
-* [`spinnaker-community` GCP project](https://console.cloud.google.com/home/dashboard?organizationId=912934373776&project=spinnaker-community){:target="\_blank"}
-  * [Instance Groups](https://console.cloud.google.com/compute/instanceGroups/list?organizationId=912934373776&project=spinnaker-community&instanceGroupsTablesize=50&instanceGroupsTablequery=%255B%257B_22k_22_3A_22name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22gcp*_5C_22_22%257D%255D){:target="\_blank"} named `gcp<testName>-*`
-  * [VMs](https://console.cloud.google.com/compute/instances?organizationId=912934373776&project=spinnaker-community&instancessize=50&instancesquery=%255B%257B_22k_22_3A_22name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22jenkins-validate-bom*_5C_22_22%257D%255D){:target="\_blank"} named `jenkins-validate-bom-*`
-  * [Load balancers](https://console.cloud.google.com/net-services/loadbalancing/loadBalancers/list?project=spinnaker-community&organizationId=912934373776&filter=%255B%257B_22k_22_3A_22Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22gcp*_5C_22_22%257D%255D){:target="\_blank"} named `gcp<testName>-*`
-  * [Managed certificates](https://console.cloud.google.com/net-services/loadbalancing/advanced/sslCertificates/list?project=spinnaker-community&organizationId=912934373776&sslCertificateTablesize=50&sslCertificateTablequery=%255B%257B_22k_22_3A_22domain_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22localhost_5C_22_22%257D%255D){:target="\_blank"} that are _**not**_ `builds.spinnaker.io` (!)
+* [`spinnaker-community` GCP project](https://console.cloud.google.com/home/dashboard?organizationId=912934373776&project=spinnaker-community)
+  * [Instance Groups](https://console.cloud.google.com/compute/instanceGroups/list?organizationId=912934373776&project=spinnaker-community&instanceGroupsTablesize=50&instanceGroupsTablequery=%255B%257B_22k_22_3A_22name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22gcp*_5C_22_22%257D%255D) named `gcp<testName>-*`
+  * [VMs](https://console.cloud.google.com/compute/instances?organizationId=912934373776&project=spinnaker-community&instancessize=50&instancesquery=%255B%257B_22k_22_3A_22name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22jenkins-validate-bom*_5C_22_22%257D%255D) named `jenkins-validate-bom-*`
+  * [Load balancers](https://console.cloud.google.com/net-services/loadbalancing/loadBalancers/list?project=spinnaker-community&organizationId=912934373776&filter=%255B%257B_22k_22_3A_22Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22gcp*_5C_22_22%257D%255D) named `gcp<testName>-*`
+  * [Managed certificates](https://console.cloud.google.com/net-services/loadbalancing/advanced/sslCertificates/list?project=spinnaker-community&organizationId=912934373776&sslCertificateTablesize=50&sslCertificateTablequery=%255B%257B_22k_22_3A_22domain_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22localhost_5C_22_22%257D%255D) that are _**not**_ `builds.spinnaker.io` (!)
 
 ## Deleting Obsolete Artifacts
 
 The following jobs assist in removing old artifacts created during the build process:
-* [Admin_DailyJanitor](https://builds.spinnaker.io/view/5%20Admin/job/Admin_DailyJanitor/){:target="\_blank"}
-* [Admin_AuditBoms](https://builds.spinnaker.io/view/5%20Admin/job/Admin_AuditBoms/){:target="\_blank"}
-* [Admin_DeleteObsoleteArtifacts](https://builds.spinnaker.io/view/5%20Admin/job/Admin_DeleteObsoleteArtifacts/){:target="\_blank"}
+* [Admin_DailyJanitor](https://builds.spinnaker.io/view/5%20Admin/job/Admin_DailyJanitor/)
+* [Admin_AuditBoms](https://builds.spinnaker.io/view/5%20Admin/job/Admin_AuditBoms/)
+* [Admin_DeleteObsoleteArtifacts](https://builds.spinnaker.io/view/5%20Admin/job/Admin_DeleteObsoleteArtifacts/)
 
 ## Troubleshooting Playbook
 

--- a/content/en/docs/setup/artifacts/gcs.md
+++ b/content/en/docs/setup/artifacts/gcs.md
@@ -6,14 +6,14 @@ sidebar:
 ---
 
 Spinnaker stages that read data from artifacts can consume
-[GCS](https://cloud.google.com/storage/){:target="\_blank"} objects as artifacts.
+[GCS](https://cloud.google.com/storage/) objects as artifacts.
 
 ## Prerequisites
 
-You need a [Google Cloud Platform](https://cloud.google.com/){:target="\_blank"}
+You need a [Google Cloud Platform](https://cloud.google.com/)
 (GCP) project to host a bucket in. The next steps assume you've already [created a
-project](https://cloud.google.com/resource-manager/docs/creating-managing-projects){:target="\_blank"},
-and installed [`gcloud`](https://cloud.google.com/sdk/downloads){:target="\_blank"}.
+project](https://cloud.google.com/resource-manager/docs/creating-managing-projects),
+and installed [`gcloud`](https://cloud.google.com/sdk/downloads).
 You can check that `gcloud` is installed and authenticated by running:
 
 ```bash
@@ -23,7 +23,7 @@ gcloud info
 ### Downloading credentials
 
 Spinnaker needs a [service
-account](https://cloud.google.com/compute/docs/access/service-accounts){:target="\_blank"}
+account](https://cloud.google.com/compute/docs/access/service-accounts)
 to authenticate as against GCP, with the `roles/storage.admin` role enabled. If
 you don't already have such a service account with the corresponding JSON key
 downloaded, you can run the following commands to do so:

--- a/content/en/docs/setup/artifacts/github.md
+++ b/content/en/docs/setup/artifacts/github.md
@@ -6,17 +6,17 @@ sidebar:
 ---
 
 Spinnaker can be configured to listen to changes to a repository in
-[GitHub](https://github.com){:target="\_blank"}.
+[GitHub](https://github.com).
 These steps show you how to configure a GitHub artifact account so that
 Spinnaker can download files from GitHub.
 
 ## Prerequisites
 
-* You need a [GitHub](https://github.com){:target="\_blank"} account.
+* You need a [GitHub](https://github.com) account.
 
 ### Downloading credentials
 
-Start by generating an [access token](https://github.com/settings/tokens){:target="\_blank"}
+Start by generating an [access token](https://github.com/settings/tokens)
 for GitHub. The token requires the __repo__ scope.
 
 Place the token in a file (`$TOKEN_FILE`) readable by Halyard:

--- a/content/en/docs/setup/artifacts/gitlab.md
+++ b/content/en/docs/setup/artifacts/gitlab.md
@@ -10,11 +10,11 @@ Spinnaker can download files from GitLab.
 
 ## Prerequisites
 
-* You need a [GitLab](https://gitlab.com){:target="\_blank"} account.
+* You need a [GitLab](https://gitlab.com) account.
 
 ### Downloading credentials
 
-Start by generating an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html){:target="\_blank"}
+Start by generating an [access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
 for GitLab.
 
 Place the token in a file (`$TOKEN_FILE`) readable by Halyard:

--- a/content/en/docs/setup/artifacts/oracle.md
+++ b/content/en/docs/setup/artifacts/oracle.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 Spinnaker stages that read data from artifacts can consume
-[Oracle Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm){:target="\_blank"} objects as artifacts.
+[Oracle Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) objects as artifacts.
 
 ## Prerequisites
 
@@ -14,35 +14,35 @@ If you have enabled [Oracle Cloud provider](/docs/setup/install/providers/oracle
 
 * A user in IAM for the person or system who will be using Spinnaker, and that user must be granted access to Object Storage or in one IAM group with permissions of Object Storage.
 
-   See [Adding Users](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/addingusers.htm){:target="\_blank"}, and [Object Storage Policy](https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/objectstoragepolicyreference.htm){:target="\_blank"}
+   See [Adding Users](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/addingusers.htm), and [Object Storage Policy](https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/objectstoragepolicyreference.htm)
 
 * The user's home region. 
 
-   See [Managing Regions](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingregions.htm){:target="\_blank"}. 
+   See [Managing Regions](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingregions.htm). 
    (e.g. `--region us-ashburn-1`)
    
 * RSA key pair in PEM format (minimum 2048 bits).
    
-   See [How to Generate an API Signing Key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How){:target="\_blank"}. 
+   See [How to Generate an API Signing Key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How). 
    (e.g. `--ssh-private-key-file-path /home/ubuntu/.oci/myPrivateKey.pem`)
    
 * Fingerprint of the public key. 
 
-   See [How to Get the Key's Fingerprint](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How3){:target="\_blank"}. 
+   See [How to Get the Key's Fingerprint](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How3). 
    (e.g. `--fingerprint 11:22:33:..:aa`)
    
 * Tenancy's OCID and user's OCID.
 
-   See [Where to Get the Tenancy's OCID and User's OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#Other){:target="\_blank"}. 
+   See [Where to Get the Tenancy's OCID and User's OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#Other). 
    (e.g. `--tenancyId ocid1.tenancy.oc1..aa... --user-id ocid1.user.oc1..aa...`)
    
 * Upload the public key from the key pair in the Console. 
    
-   See [How to Upload the Public Key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How2){:target="\_blank"}.
+   See [How to Upload the Public Key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How2).
    
 * Namespace: this is your Tenancy name. On Oracle Cloud Console, click on the user menu. The Tenancy name is next to your user name. 
 
-   See [Object Storage Namespaces](https://docs.cloud.oracle.com/iaas/Content/Object/Tasks/understandingnamespaces.htm){:target="\_blank"}, and [Managing Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm){:target="\_blank"}. 
+   See [Object Storage Namespaces](https://docs.cloud.oracle.com/iaas/Content/Object/Tasks/understandingnamespaces.htm), and [Managing Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm). 
    (e.g. `--namespace my-tenancy`)
    
 ## Add Oracle Object Storage Artifact to Spinnaker

--- a/content/en/docs/setup/bakery/_index.md
+++ b/content/en/docs/setup/bakery/_index.md
@@ -25,12 +25,12 @@ There are two types of configuration of the Bakery:
 ## Packer Templates
 
 Every time you initiate a bake using Spinnaker, Spinnaker invokes a [packer
-template](https://www.packer.io/docs/templates/index.html){:target="\_blank"}
-with a mix of [variables](https://www.packer.io/docs/templates/index.html){:target="\_blank"}
+template](https://www.packer.io/docs/templates/index.html)
+with a mix of [variables](https://www.packer.io/docs/templates/index.html)
 provided by you, the Pipeline you are currently executing, and Spinnaker itself.
 All of the default packer templates are versioned alongside Rosco, the image
 bakery service
-[here](https://github.com/spinnaker/rosco/tree/master/rosco-web/config/packer){:target="\_blank"}.
+[here](https://github.com/spinnaker/rosco/tree/master/rosco-web/config/packer).
 If want to override/include a new template, place it into
 `~/.hal/$DEPLOYMENT/profiles/rosco/packer/` (`$DEPLOYMENT` is
 typically `default`, read more [here](/reference/halyard/#deployments)). Any local

--- a/content/en/docs/setup/canary/_index.md
+++ b/content/en/docs/setup/canary/_index.md
@@ -239,8 +239,8 @@ hal config canary datadog account list
 ## Set up canary analysis for Google
 
 Configure your canary analysis to work with
-Google, including [Stackdriver](https://cloud.google.com/stackdriver){:target="\_blank"}
-and [GCS](https://cloud.google.com/storage/){:target="\_blank"}.
+Google, including [Stackdriver](https://cloud.google.com/stackdriver)
+and [GCS](https://cloud.google.com/storage/).
 
 
 ### Enable/disable your Google service integration

--- a/content/en/docs/setup/ci/jenkins.md
+++ b/content/en/docs/setup/ci/jenkins.md
@@ -9,7 +9,7 @@ aliases:
 
 
 
-Setting up [Jenkins](https://jenkins.io/){:target="\_blank"} as a Continuous
+Setting up [Jenkins](https://jenkins.io/) as a Continuous
 Integration (CI) system within Spinnaker lets you trigger pipelines with
 Jenkins, add a Jenkins stage to your pipeline, or add a Script stage to your
 pipeline.
@@ -44,7 +44,7 @@ human-readable name), to your list of Jenkins masters:
    ```
 
    > *Note*: If you use the [GitHub OAuth
-   > plugin](https://wiki.jenkins.io/display/JENKINS/GitHub+OAuth+Plugin){:target="\_blank"}
+   > plugin](https://wiki.jenkins.io/display/JENKINS/GitHub+OAuth+Plugin)
    > for authentication into Jenkins, you can use the GitHub $USERNAME, and use the
    > OAuth token as the $APIKEY.
 

--- a/content/en/docs/setup/ci/travis.md
+++ b/content/en/docs/setup/ci/travis.md
@@ -8,7 +8,7 @@ sidebar:
 
 
 You can configure Spinnaker to use [Travis
-CI](https://travis-ci.org/){:target="\_blank"} as your Continuous Integration
+CI](https://travis-ci.org/) as your Continuous Integration
 system, trigger pipelines with Travis, or add a Travis stage to a pipeline.
 
 ## Prerequisites

--- a/content/en/docs/setup/features/notifications/index.md
+++ b/content/en/docs/setup/features/notifications/index.md
@@ -42,7 +42,7 @@ You need to set the `spinnaker.baseUrl` configuration value which is used by spi
 ## Email
 
 Email in spinnaker is provided by [Spring Boot Mail
-starter](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-email.html){:target="\_blank"}.
+starter](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-email.html).
 The following is an example of using hotmail to send notifications.
 
 in echo.yml
@@ -77,7 +77,7 @@ window.spinnakerSettings.notifications.email.enabled = true;
 ## Slack
 
 For slack, you need to [create a custom bot
-user](https://api.slack.com/bot-users#how_do_i_create_custom_bot_users_for_my_team){:target="\_blank"},
+user](https://api.slack.com/bot-users#how_do_i_create_custom_bot_users_for_my_team),
 then get the access token associated with that new bot user. Then...
 
 ```bash
@@ -89,7 +89,7 @@ Note: your users will need to invite the slack bot to private rooms that want to
 
 ## Twilio
 
-For Twilio, you need to add your account [credentials](https://support.twilio.com/hc/en-us/articles/223136027-Auth-Tokens-and-how-to-change-them){:target="\_blank"}. Then...
+For Twilio, you need to add your account [credentials](https://support.twilio.com/hc/en-us/articles/223136027-Auth-Tokens-and-how-to-change-them). Then...
 
 ```bash
 hal config notification twilio enable
@@ -235,7 +235,7 @@ You can access the hash of the build via expression ```${trigger.hash}```
 
 ## Add a listening webhook to spinnaker
 
-The [echo-rest](https://github.com/spinnaker/echo/tree/master/echo-rest){:target="\_blank"}
+The [echo-rest](https://github.com/spinnaker/echo/tree/master/echo-rest)
 module in spinnaker allows you to set downstream listeners keeping track of
 Spinnaker events.
 

--- a/content/en/docs/setup/features/user-data.md
+++ b/content/en/docs/setup/features/user-data.md
@@ -7,8 +7,8 @@ sidebar:
 
 Spinnaker refers to data injected into instances started by Spinnaker as *user data*.
 The implementation and naming of this varies from provider to provider, but the resulting functionality is similar.
-In AWS, it is known as [User Data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html){:target="\_blank"}.
-In GCP, it is known as [Instance Metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata){:target="\_blank"}.
+In AWS, it is known as [User Data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
+In GCP, it is known as [Instance Metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata).
 The template file used to define the user data is called the *user data file* which is located on the Clouddriver server.
 Tokens are replaced in the user data file to provide some specifics about the deployment.
 Every instance started has environment variables are set according to the template and the deployment.
@@ -95,7 +95,7 @@ With Google, the user data file is set per account.
 It is best practice to use the same file for different accounts to ensure consistency,
 but different user data files can be used for different accounts if needed.
 The contents of the this file is parsed and set as the
-[Instance Metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata){:target="\_blank"} on launched instances.
+[Instance Metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata) on launched instances.
 Any metadata defined in the server group configuration within Spinnaker is
 appended to the metadata defined by the *user data file*.
 The metadata defined in the server group configuration within Spinnaker takes preferences over the metadata defined in the *user data file* if the metadata keys match.

--- a/content/en/docs/setup/install/deploy.md
+++ b/content/en/docs/setup/install/deploy.md
@@ -77,7 +77,7 @@ as described
 ## Troubleshooting
 
 If this command fails, and it's the first time you've run this command please
-reach out to us on [Slack](http://join.spinnaker.io){:target="\_blank"}.
+reach out to us on [Slack](http://join.spinnaker.io).
 If you've had a successful deployment, you can run `hal deploy diff` to see what
 changes you've made that may be causing problems. At any point you can rerun
 `hal deploy apply` with any changes you've made to retry the deployment.

--- a/content/en/docs/setup/install/halyard.md
+++ b/content/en/docs/setup/install/halyard.md
@@ -103,7 +103,7 @@ run the following command:
 > and write to it.
 
 1. Make sure you have [Docker CE
-installed](https://docs.docker.com/engine/installation/){:target="\_blank"}.
+installed](https://docs.docker.com/engine/installation/).
 
 1. On your current machine, make a local Halyard config directory.
 

--- a/content/en/docs/setup/install/providers/appengine.md
+++ b/content/en/docs/setup/install/providers/appengine.md
@@ -9,17 +9,17 @@ aliases:
 
 
 
-In [Google App Engine](https://cloud.google.com/appengine){:target="\_blank"}, an
+In [Google App Engine](https://cloud.google.com/appengine), an
 [__Account__](/concepts/providers/#accounts) maps to a credential able to
 authenticate against a given [Google Cloud
-Platform](https://cloud.google.com){:target="\_blank"} project.
+Platform](https://cloud.google.com) project.
 
 ## Prerequisites
 
-You need a [Google Cloud Platform](https://cloud.google.com/){:target="\_blank"}
+You need a [Google Cloud Platform](https://cloud.google.com/)
 project to run Spinnaker against. The next steps assume you've already [created
-a project](https://cloud.google.com/resource-manager/docs/creating-managing-projects){:target="\_blank"},
-and installed [`gcloud`](https://cloud.google.com/sdk/downloads){:target="\_blank"}.
+a project](https://cloud.google.com/resource-manager/docs/creating-managing-projects),
+and installed [`gcloud`](https://cloud.google.com/sdk/downloads).
 You can check that `gcloud` is installed and authenticated by running:
 
 ```bash
@@ -41,7 +41,7 @@ gcloud services enable appengine.googleapis.com
 
 ## Downloading credentials
 
-Spinnaker does not need to be given [service account](https://cloud.google.com/compute/docs/access/service-accounts){:target="\_blank"}
+Spinnaker does not need to be given [service account](https://cloud.google.com/compute/docs/access/service-accounts)
 credentials if it is running on a Google Compute Engine VM whose
 application default credentials have sufficient scopes to deploy to App Engine _and_
 Spinnaker is deploying to an App Engine application inside the same Google Cloud Platform project in which it is running. If

--- a/content/en/docs/setup/install/providers/aws/aws-ec2.md
+++ b/content/en/docs/setup/install/providers/aws/aws-ec2.md
@@ -11,16 +11,16 @@ sidebar:
 > worked on. In the meantime, please use the following
 > [AWS install tutorial](https://aws.amazon.com/blogs/opensource/continuous-delivery-spinnaker-amazon-eks/).
 
-In [AWS](https://aws.amazon.com/){:target="\_blank"}, an [__Account__](/concepts/providers/#accounts)
+In [AWS](https://aws.amazon.com/), an [__Account__](/concepts/providers/#accounts)
 maps to a credential able to authenticate against a given [AWS
-account](https://aws.amazon.com/account/){:target="\_blank"}.
+account](https://aws.amazon.com/account/).
 
 ## Option-1 : Use AWS Console to configure AWS
 
 Use this option to deploy Spinnaker, if you are familar with deployment using [AWS Console](https://console.aws.amazon.com/) .
 
 ### Managing Account
-1. Navigate to [Console](https://console.aws.amazon.com/){:target="\_blank"} > CloudFormation and [select](https://docs.aws.amazon.com/awsconsolehelpdocs/latest/gsg/getting-started.html#select-region) your preferred region.
+1. Navigate to [Console](https://console.aws.amazon.com/) > CloudFormation and [select](https://docs.aws.amazon.com/awsconsolehelpdocs/latest/gsg/getting-started.html#select-region) your preferred region.
 2. Download [the template](https://d3079gxvs8ayeg.cloudfront.net/templates/managing.yaml) locally to your workstation.
 
     2.a (Optional). Add additional managed account as shown on line 158 in the SpinnakerAssumeRolePolicy section of the downloaded template file.
@@ -34,7 +34,7 @@ Use this option to deploy Spinnaker, if you are familar with deployment using [A
 
 > These steps need to be carried out for the managing account as well.
 
-1. Navigate to [Console](https://console.aws.amazon.com/){:target="\_blank"} > CloudFormation and [select](https://docs.aws.amazon.com/awsconsolehelpdocs/latest/gsg/getting-started.html#select-region) your preferred region.
+1. Navigate to [Console](https://console.aws.amazon.com/) > CloudFormation and [select](https://docs.aws.amazon.com/awsconsolehelpdocs/latest/gsg/getting-started.html#select-region) your preferred region.
 2. Download [the template](https://d3079gxvs8ayeg.cloudfront.net/templates/managed.yaml) locally to your workstation.
 3. Creating the CloudFormation Stack
     * __Create Stack__ > __Upload a template to Amazon S3__ > __Browse to template you downloaded in Step-2 above__ > __Next__

--- a/content/en/docs/setup/install/providers/aws/aws-ecs.md
+++ b/content/en/docs/setup/install/providers/aws/aws-ecs.md
@@ -9,13 +9,13 @@ sidebar:
 
 In the Amazon ECS cloud provider, an [__Account__](/concepts/providers/#accounts)
 maps to a Spinnaker AWS account, which itself is able to authenticate against a given [AWS
-account](https://aws.amazon.com/account/){:target="\_blank"}.
+account](https://aws.amazon.com/account/).
 
 ## Prerequisites
 
 ### Amazon ECS cluster
 
-You need to [create an Amazon ECS cluster](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create_cluster.html){:target="\_blank"}. If using the 'EC2' launch type, this cluster must have enough EC2 instance capacity in it to deploy your containers.  If using the 'Fargate' launch type, you don't need to add any capacity to this cluster.
+You need to [create an Amazon ECS cluster](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create_cluster.html). If using the 'EC2' launch type, this cluster must have enough EC2 instance capacity in it to deploy your containers.  If using the 'Fargate' launch type, you don't need to add any capacity to this cluster.
 
 ### Networking
 
@@ -32,11 +32,11 @@ aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com
 aws iam create-service-linked-role --aws-service-name ecs.application-autoscaling.amazonaws.com
 ```
 
-See the [Amazon ECS service-linked role documentation](https://docs.aws.amazon.com/AmazonECS/latest/userguide/using-service-linked-roles.html){:target="\_blank"} and the [Application Auto Scaling service-linked role documentation](https://docs.aws.amazon.com/autoscaling/application/userguide/application-auto-scaling-service-linked-roles.html){:target="\_blank"} for information on the permissions in these roles.
+See the [Amazon ECS service-linked role documentation](https://docs.aws.amazon.com/AmazonECS/latest/userguide/using-service-linked-roles.html) and the [Application Auto Scaling service-linked role documentation](https://docs.aws.amazon.com/autoscaling/application/userguide/application-auto-scaling-service-linked-roles.html) for information on the permissions in these roles.
 
 ### Legacy IAM Roles (prior to 1.19)
 
-In Spinnaker versions 1.18 and below, the Amazon ECS cloud provider uses [legacy IAM roles for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-legacy-iam-roles.html){:target="\_blank"}.  The provider uses the cloud provider account's assumed IAM role as both the [Service Scheduler IAM role](https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-legacy-iam-roles.html#service_IAM_role){:target="\_blank"} and the [Service Auto Scaling IAM role](https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-legacy-iam-roles.html#autoscale_IAM_role){:target="\_blank"} for the server group's Amazon ECS service.
+In Spinnaker versions 1.18 and below, the Amazon ECS cloud provider uses [legacy IAM roles for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-legacy-iam-roles.html).  The provider uses the cloud provider account's assumed IAM role as both the [Service Scheduler IAM role](https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-legacy-iam-roles.html#service_IAM_role) and the [Service Auto Scaling IAM role](https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-legacy-iam-roles.html#autoscale_IAM_role) for the server group's Amazon ECS service.
 
 The IAM role for the cloud provider account associated with the Amazon ECS server group must allow both Amazon ECS and Application Auto Scaling to assume the role in its trust policy.
 
@@ -58,11 +58,11 @@ The IAM role for the cloud provider account associated with the Amazon ECS serve
 }
 ```
 
-For information on how to configure the IAM role associated with the cloud provider account, see the [AWS provider documentation](/docs/setup/install/providers/aws/aws-ec2/).  For information on how to modify IAM roles in the AWS console, see the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_modify.html){:target="\_blank"}.
+For information on how to configure the IAM role associated with the cloud provider account, see the [AWS provider documentation](/docs/setup/install/providers/aws/aws-ec2/).  For information on how to modify IAM roles in the AWS console, see the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_modify.html).
 
 ### Task Execution IAM Role
 
-Some Amazon ECS services require a [task execution IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html){:target="\_blank"}, such as services running on AWS Fargate.  If you are using task definition artifacts in your Spinnaker pipeline, the task execution role can be specified in the artifact's task definition file.
+Some Amazon ECS services require a [task execution IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html), such as services running on AWS Fargate.  If you are using task definition artifacts in your Spinnaker pipeline, the task execution role can be specified in the artifact's task definition file.
 
 If you are not using a task definition artifact (or if the artifact's task definition file does not specify a task execution role) for a server group running on Fargate, the Amazon ECS cloud provider will fallback to using the cloud provider account's assumed IAM role as the task execution role.  In that situation, the IAM role for the cloud provider account associated with the Amazon ECS server group must allow Amazon ECS to assume the role in its trust policy.
 
@@ -83,11 +83,11 @@ If you are not using a task definition artifact (or if the artifact's task defin
 }
 ```
 
-For information on how to configure the IAM role associated with the cloud provider account, see the [AWS provider documentation](/docs/setup/install/providers/aws/aws-ec2/).  For information on how to modify IAM roles in the AWS console, see the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_modify.html){:target="\_blank"}.
+For information on how to configure the IAM role associated with the cloud provider account, see the [AWS provider documentation](/docs/setup/install/providers/aws/aws-ec2/).  For information on how to modify IAM roles in the AWS console, see the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_modify.html).
 
 ### Optional: IAM Roles for Tasks
 
-You can create [IAM roles for tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html){:target="\_blank"} and associate them to your Amazon ECS provider server group in Spinnaker, so that your application's containers have access to IAM role credentials.  The task role must allow Amazon ECS to assume the role in its trust policy.
+You can create [IAM roles for tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) and associate them to your Amazon ECS provider server group in Spinnaker, so that your application's containers have access to IAM role credentials.  The task role must allow Amazon ECS to assume the role in its trust policy.
 
 ```json
 {
@@ -105,11 +105,11 @@ You can create [IAM roles for tasks](https://docs.aws.amazon.com/AmazonECS/lates
 }
 ```
 
-For information on how to modify IAM roles in the AWS console, see the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_modify.html){:target="\_blank"}.
+For information on how to modify IAM roles in the AWS console, see the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_modify.html).
 
 ### Optional: Service Auto Scaling
 
-You can configure your Amazon ECS services to use [Service Auto Scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-auto-scaling.html){:target="\_blank"}.  Service Auto Scaling policies adjust your Amazon ECS service's desired count up or down in response to CloudWatch alarms (e.g. tracking the CPU utilization of an Amazon ECS service, or tracking a custom metric) or on a schedule (e.g. scale up on Monday, scale down on Friday).
+You can configure your Amazon ECS services to use [Service Auto Scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-auto-scaling.html).  Service Auto Scaling policies adjust your Amazon ECS service's desired count up or down in response to CloudWatch alarms (e.g. tracking the CPU utilization of an Amazon ECS service, or tracking a custom metric) or on a schedule (e.g. scale up on Monday, scale down on Friday).
 
 Configure scaling policies on your Amazon ECS services using the Application Auto Scaling APIs or in the Amazon ECS console, outside of Spinnaker.  When deploying a new server group in Spinnaker, you can copy these scaling policies from the previous service group by enabling the "copy the previous server group's autoscaling policies" option.
 

--- a/content/en/docs/setup/install/providers/azure.md
+++ b/content/en/docs/setup/install/providers/azure.md
@@ -9,16 +9,16 @@ aliases:
 
 
 
-In [Azure](https://azure.microsoft.com/){:target="\_blank"}, an
+In [Azure](https://azure.microsoft.com/), an
 [__Account__](/concepts/providers/#accounts) maps to a credential able to
-authenticate against a given [Azure subscription](https://azure.microsoft.com/free/){:target="\_blank"}.
+authenticate against a given [Azure subscription](https://azure.microsoft.com/free/).
 
 ## Prerequisites
 
-You need a [Service Principal](https://docs.microsoft.com/cli/azure/create-an-azure-service-principal-azure-cli){:target="\_blank"}
-to authenticate with Azure and a [Key Vault](https://azure.microsoft.com/services/key-vault/){:target="\_blank"}
-to store a default username/ssh public key for deployed [VM Scale Sets](https://docs.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-overview){:target="\_blank"}.
-The next steps assume the use of the [Azure CLI 2.0](https://docs.microsoft.com/cli/azure/install-azure-cli){:target="\_blank"}.
+You need a [Service Principal](https://docs.microsoft.com/cli/azure/create-an-azure-service-principal-azure-cli)
+to authenticate with Azure and a [Key Vault](https://azure.microsoft.com/services/key-vault/)
+to store a default username/ssh public key for deployed [VM Scale Sets](https://docs.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-overview).
+The next steps assume the use of the [Azure CLI 2.0](https://docs.microsoft.com/cli/azure/install-azure-cli).
 The example commands will set environment variables along the way for use when
 creating an account in the final stage. You can check that you have `az` installed by running:
 
@@ -71,7 +71,7 @@ with
 ```bash
 az keyvault secret set --name VMPassword --vault-name $VAULT_NAME --value <Insert default password>
 ```
-Follow the Azure VM username and password rules documented [here](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/faq#what-are-the-username-requirements-when-creating-a-vm){:target="\_blank"}.
+Follow the Azure VM username and password rules documented [here](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/faq#what-are-the-username-requirements-when-creating-a-vm).
 
 ## Adding an account
 

--- a/content/en/docs/setup/install/providers/docker-registry.md
+++ b/content/en/docs/setup/install/providers/docker-registry.md
@@ -15,7 +15,7 @@ aliases:
 When configuring Docker Registries, an
 [__Account__](/concepts/providers/#accounts) maps to a credential able to
 authenticate against a certain set of [Docker
-repositories](https://docs.docker.com/glossary/?term=repository){:target="\_blank"}.
+repositories](https://docs.docker.com/glossary/?term=repository).
 
 Perform the steps in this article in the same place where you have Halyard
 installed, whether [in a Docker
@@ -26,9 +26,9 @@ Ubuntu/Debian or macOS](/docs/setup/install/halyard/#update-halyard-on-debianubu
 
 * The Docker Registry you are configuring must already exist.
 * That Registry must support the
-[v2 registry API](https://docs.docker.com/registry/spec/api/){:target="\_blank"}.
+[v2 registry API](https://docs.docker.com/registry/spec/api/).
 * If the Registry doesn't have at least 1
-[tag](https://docs.docker.com/glossary/?term=tag){:target="\_blank"} among the
+[tag](https://docs.docker.com/glossary/?term=tag) among the
 repositories you define in your Account, Halyard throws a warning.
 
 ## Registry providers
@@ -57,7 +57,7 @@ ADDRESS=index.docker.io
 ```
 
 Dockerhub hosts a mix of public and private repositories, but does not expose a
-[catalog](https://docs.docker.com/registry/spec/api/#listing-repositories){:target="\_blank"}
+[catalog](https://docs.docker.com/registry/spec/api/#listing-repositories)
 endpoint to programmatically list them. Therefore you need to explicitly list
 which Docker repositories you want to index and deploy. For example, if you
 wanted to deploy the public NGINX image, alongside your private `app` image,
@@ -85,30 +85,30 @@ PASSWORD=hunter2
 
    There are a few different registry addresses for GCR, depending on where you
    want to store your images. The most likely address is `gcr.io`, but there are
-   [more options available](https://cloud.google.com/container-registry/docs/pushing#pushing_to_the_registry){:target="\_blank"}.
+   [more options available](https://cloud.google.com/container-registry/docs/pushing#pushing_to_the_registry).
 
    ```bash
    ADDRESS=gcr.io
    ```
 
 1. (Optional) Enable the [Resource Manager
-API](https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/overview){:target="\_blank"}.
+API](https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/overview).
 
    Enable this API if you want to use the
-   [catalog](https://docs.docker.com/registry/spec/api/#listing-repositories){:target="\_blank"}
+   [catalog](https://docs.docker.com/registry/spec/api/#listing-repositories)
    endpoint to programatically list all images available to your credentials,
    so you don't have supply repositories manually.
 
-1. Set up [authentication](https://cloud.google.com/container-registry/docs/advanced-authentication){:target="\_blank"}.
+1. Set up [authentication](https://cloud.google.com/container-registry/docs/advanced-authentication).
 
-   A [service account](https://cloud.google.com/compute/docs/access/service-accounts){:target="\_blank"}
+   A [service account](https://cloud.google.com/compute/docs/access/service-accounts)
    is the preferred way to authenticate to GCR. Use the commands below to create
    and download a service account to be used as your password with the required
    `roles/storage.admin` role, assuming the registry exists in your current
    `gcloud` project.
 
    (You can use an [access
-   token](https://cloud.google.com/container-registry/docs/advanced-authentication#access_token){:target="\_blank"}
+   token](https://cloud.google.com/container-registry/docs/advanced-authentication#access_token)
    instead, but that's problematic for Spinnaker because the token is short
    lived, and you are responsible for refreshing it.)
 
@@ -223,7 +223,7 @@ Most registries fit either the Dockerhub or GCR pattern described above,
 or some mix of the two. In all cases you need to know the FQDN of the
 registry, and your username/password pair if you are accessing private images.
 If your registry supports the [`/_catalog`
-endpoint](https://docs.docker.com/registry/spec/api/#listing-repositories){:target="\_blank"}
+endpoint](https://docs.docker.com/registry/spec/api/#listing-repositories)
 you do not have to list your repositories. If it does not, keep in mind that the
 repository names are generally of the form `<username>/<image name>`. Halyard
 verifies this for you.

--- a/content/en/docs/setup/install/providers/gce.md
+++ b/content/en/docs/setup/install/providers/gce.md
@@ -9,18 +9,18 @@ aliases:
 
 
 
-In [Google Compute Engine](https://cloud.google.com/compute){:target="\_blank"}
+In [Google Compute Engine](https://cloud.google.com/compute)
 (GCE), an [__Account__](/concepts/providers/#accounts) maps to a credential able
 to authenticate against a given [Google Cloud
-Platform](https://cloud.google.com/){:target="\_blank"} (GCP) project.
+Platform](https://cloud.google.com/) (GCP) project.
 
 ## Prerequisites
 
-You need a [Google Cloud Platform](https://cloud.google.com/){:target="\_blank"}
+You need a [Google Cloud Platform](https://cloud.google.com/)
 (GCP) project to run Spinnaker against. The next steps assume you've already
 [created a
-project](https://cloud.google.com/resource-manager/docs/creating-managing-projects){:target="\_blank"},
-and installed [`gcloud`](https://cloud.google.com/sdk/downloads){:target="\_blank"}.
+project](https://cloud.google.com/resource-manager/docs/creating-managing-projects),
+and installed [`gcloud`](https://cloud.google.com/sdk/downloads).
 You can check that `gcloud` is installed and authenticated by running:
 
 ```bash
@@ -30,7 +30,7 @@ gcloud info
 ### Downloading credentials
 
 Spinnaker needs a [service
-account](https://cloud.google.com/compute/docs/access/service-accounts){:target="\_blank"}
+account](https://cloud.google.com/compute/docs/access/service-accounts)
 to authenticate as against GCE, with the role enumerated below enabled. If
 you don't already have such a service account with the corresponding JSON key
 downloaded, you can run the following commands to do so:

--- a/content/en/docs/setup/install/providers/kubernetes-v2/k8s-provider.md
+++ b/content/en/docs/setup/install/providers/kubernetes-v2/k8s-provider.md
@@ -9,8 +9,8 @@ description: >
 
 
 Spinnaker's Kubernetes provider fully supports Kubernetes-native, manifest-based deployments and is the recommended provider for deploying to Kubernetes with Spinnaker.
-[Spinnaker's legacy Kubernetes provider](https://www.spinnaker.io/setup/install/providers/kubernetes/){:target="\_blank"}
-is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md){:target="\_blank"} in Spinnaker 1.21.
+[Spinnaker's legacy Kubernetes provider](https://www.spinnaker.io/setup/install/providers/kubernetes/)
+is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md) in Spinnaker 1.21.
 
 ## Accounts
 
@@ -21,14 +21,14 @@ credential that can authenticate against your Kubernetes Cluster.
 
 The Kubernetes provider has two requirements:
 
-* A [`kubeconfig`](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/){:target="\_blank"} file
+* A [`kubeconfig`](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) file
 
     The `kubeconfig` file allows Spinnaker to authenticate against your cluster
     and to have read/write access to any resources you expect it to manage. You
     can think of it as private key file to let Spinnaker connect to your cluster.
     You can request this from your Kubernetes cluster administrator.
 
-* [`kubectl`](https://kubernetes.io/docs/user-guide/kubectl/){:target="\_blank"} CLI tool
+* [`kubectl`](https://kubernetes.io/docs/user-guide/kubectl/) CLI tool
 
     Spinnaker relies on `kubectl` to manage all API access. It's installed
     along with Spinnaker.
@@ -83,7 +83,7 @@ kubectl config set-context $CONTEXT --user ${CONTEXT}-token-user
 ### Optional: Configure Kubernetes roles (RBAC)
 
 If your Kubernetes cluster supports
-[RBAC](https://kubernetes.io/docs/admin/authorization/rbac/){:target="\_blank"}
+[RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)
 and you want to restrict permissions granted to your Spinnaker account, you
 will need to follow the below instructions.
 
@@ -93,7 +93,7 @@ namespaces (using the `namespaces` option), you need to use `Role` &
 `RoleBinding` instead of `ClusterRole` and `ClusterRoleBinding`, and apply the
 `Role` and `RoleBinding` to each namespace Spinnaker manages. You can read
 about the difference between `ClusterRole` and `Role`
-[here](https://kubernetes.io/docs/admin/authorization/rbac/#rolebinding-and-clusterrolebinding){:target="\_blank"}.
+[here](https://kubernetes.io/docs/admin/authorization/rbac/#rolebinding-and-clusterrolebinding).
 If you're using RBAC to restrict the Spinnaker service account to a particular namespace,
 you must specify that namespace when you add the account to Spinnaker.
 If you don't specify any namespaces, then Spinnaker will attempt to list all namespaces,
@@ -166,7 +166,7 @@ reasons:
 
 * The V2 provider encourages you to leverage the Kubernetes native deployment
   orchestration (e.g.
-  [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/){:target="\_blank"})
+  [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/))
   instead of the Spinnaker red/black, where possible.
 
 * The initial operations available on Kubernetes manifests (e.g. scale, pause

--- a/content/en/docs/setup/install/providers/kubernetes.md
+++ b/content/en/docs/setup/install/providers/kubernetes.md
@@ -30,10 +30,10 @@ you'll use.
 ### You need a Kubernetes cluster and its credentials
 
 You need a running Kubernetes cluster, with corresponding credentials in a
-[kubeconfig file](https://kubernetes.io/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/){:target="\_blank"}.
+[kubeconfig file](https://kubernetes.io/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/).
 
 If you have these, and you have
-[`kubectl`](https://kubernetes.io/docs/user-guide/kubectl-overview/){:target="\_blank"}
+[`kubectl`](https://kubernetes.io/docs/user-guide/kubectl-overview/)
 installed on the machine where you have your `kubeconfig`, you can verify the
 credentials work by running this command:
 
@@ -48,16 +48,16 @@ If you don't have a Kubernetes cluster, you can try one of these hosted
 solutions:
 
 * [Azure Container
-  Service](https://docs.microsoft.com/en-us/azure/container-service/container-service-kubernetes-walkthrough){:target="\_blank"}
+  Service](https://docs.microsoft.com/en-us/azure/container-service/container-service-kubernetes-walkthrough)
 
-* [EKS](https://aws.amazon.com/eks/){:target="\_blank"}
+* [EKS](https://aws.amazon.com/eks/)
 
-* [Google Kubernetes Engine](https://cloud.google.com/container-engine/){:target="\_blank"}
+* [Google Kubernetes Engine](https://cloud.google.com/container-engine/)
 
   See the note below on getting credentials in GKE.
 
 Or pick a different [solution that works for
-you](https://kubernetes.io/docs/setup/pick-right-solution/){:target="\_blank"}.
+you](https://kubernetes.io/docs/setup/pick-right-solution/).
 
 Consult the documentation for your environment to find out how to get the
 `kubeconfig` that you must provide to Halyard.
@@ -120,7 +120,7 @@ and `ServiceAccount`. If you're limiting Spinnaker to an explicit list of
 namespaces (using the `namespaces` option), you need to use `Role` &
 `RoleBinding` instead of `ClusterRole` and `ClusterRoleBinding`, and create one
 in each namespace Spinnaker will manage. You can read about the difference
-between `ClusterRole` and `Role` [here](https://kubernetes.io/docs/admin/authorization/rbac/#rolebinding-and-clusterrolebinding){:target="\_blank"}.
+between `ClusterRole` and `Role` [here](https://kubernetes.io/docs/admin/authorization/rbac/#rolebinding-and-clusterrolebinding).
 
 
 ```yaml

--- a/content/en/docs/setup/install/providers/oracle.md
+++ b/content/en/docs/setup/install/providers/oracle.md
@@ -8,8 +8,8 @@ aliases:
 ---
 
 
-In [Oracle Cloud](https://cloud.oracle.com/){:target="\_blank"}, a Spinnaker
-[__Account__](/concepts/providers/#accounts) maps to an [Oracle Cloud Infrastructure user]( https://cloud.oracle.com/en_US/tryit){:target="\_blank"}.
+In [Oracle Cloud](https://cloud.oracle.com/), a Spinnaker
+[__Account__](/concepts/providers/#accounts) maps to an [Oracle Cloud Infrastructure user]( https://cloud.oracle.com/en_US/tryit).
 
 When setting up your Oracle Cloud provider account, you will [use halyard to add
 the account](#add-an-oracle-cloud-account).
@@ -19,24 +19,24 @@ the account](#add-an-oracle-cloud-account).
 You will need the following to enable Oracle Cloud provider in Spinnaker:
 - A user in IAM for the person or system who will be using Spinnaker, and put that user in at 
 least one IAM group with any desired permissions. 
-See [Adding Users](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/addingusers.htm#one){:target="\_blank"}. 
+See [Adding Users](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/addingusers.htm#one). 
 - The user's home region. 
-See [Managing Regions](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingregions.htm){:target="\_blank"}. 
+See [Managing Regions](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingregions.htm). 
 (e.g. `--region us-ashburn-1`)
 - RSA key pair in PEM format (minimum 2048 bits).
-See [How to Generate an API Signing Key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How){:target="\_blank"}. 
+See [How to Generate an API Signing Key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How). 
 (e.g. `--ssh-private-key-file-path /home/ubuntu/.oci/myPrivateKey.pem`)
 - Fingerprint of the public key. 
-See [How to Get the Key's Fingerprint](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How3){:target="\_blank"}. 
+See [How to Get the Key's Fingerprint](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How3). 
 (e.g. `--fingerprint 11:22:33:..:aa`)
 - Tenancy's OCID and user's OCID.
-See [Where to Get the Tenancy's OCID and User's OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#Other){:target="\_blank"}. 
+See [Where to Get the Tenancy's OCID and User's OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#Other). 
 (e.g. `--tenancyId ocid1.tenancy.oc1..aa... --user-id ocid1.user.oc1..aa...`)
 - Compartment OCID: On Oracle Cloud Console, open the navigation menu. Under Governance and Administration, go to Identity and click Compartments. 
-See [Managing Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm){:target="\_blank"}. 
+See [Managing Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm). 
 (e.g. `--compartment-id ocid1.compartment.oc1..aa...`)
 - Upload the public key from the key pair in the Console. 
-See [How to Upload the Public Key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How2){:target="\_blank"}. 
+See [How to Upload the Public Key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How2). 
 
 ## Add an Oracle Cloud account
 

--- a/content/en/docs/setup/install/storage/gcs.md
+++ b/content/en/docs/setup/install/storage/gcs.md
@@ -9,16 +9,16 @@ aliases:
 
 
 
-Using [Google Cloud Storage](https://cloud.google.com/storage/){:target="\_blank"}
+Using [Google Cloud Storage](https://cloud.google.com/storage/)
 (GCS) as a storage source means that Spinnaker will store all of its persistent
-data in a [Bucket](https://cloud.google.com/storage/docs/json_api/v1/buckets){:target="\_blank"}.
+data in a [Bucket](https://cloud.google.com/storage/docs/json_api/v1/buckets).
 
 ## Prerequisites
 
-You need a [Google Cloud Platform](https://cloud.google.com/){:target="\_blank"}
+You need a [Google Cloud Platform](https://cloud.google.com/)
 (GCP) project to host your bucket in. The next steps assume you've already
-[created a project](https://cloud.google.com/resource-manager/docs/creating-managing-projects){:target="\_blank"},
-and installed [`gcloud`](https://cloud.google.com/sdk/downloads){:target="\_blank"}.
+[created a project](https://cloud.google.com/resource-manager/docs/creating-managing-projects),
+and installed [`gcloud`](https://cloud.google.com/sdk/downloads).
 You can check that `gcloud` is installed and authenticated by running:
 
 ```bash
@@ -28,7 +28,7 @@ gcloud info
 ### Downloading credentials
 
 Spinnaker needs a [service
-account](https://cloud.google.com/compute/docs/access/service-accounts){:target="\_blank"}
+account](https://cloud.google.com/compute/docs/access/service-accounts)
 to authenticate as against GCP, with the `roles/storage.admin` role enabled. If
 you don't already have such a service account with the corresponding JSON key
 downloaded, you can run the following commands to do so:

--- a/content/en/docs/setup/install/storage/minio.md
+++ b/content/en/docs/setup/install/storage/minio.md
@@ -10,7 +10,7 @@ aliases:
 > :warning: Losing Minio's data will mean losing all your Spinnaker
 > application metadata, and configured pipelines.
 
-[Minio](https://www.minio.io/){:target="\_blank"} is an S3-compatible object
+[Minio](https://www.minio.io/) is an S3-compatible object
 store that you can host yourself. This is the persistent storage solution we
 recommend when you don't want to depend on a cloud provider to host your
 Spinnaker data.
@@ -18,7 +18,7 @@ Spinnaker data.
 ## Prerequisites
 
 Install Minio following the instructions on the [Minio
-homepage](https://www.minio.io/){:target="\_blank"}, making sure to have it run
+homepage](https://www.minio.io/), making sure to have it run
 on an endpoint reachable by Spinnaker. Record the following values:
 
 * `ENDPOINT`: The fully-qualifed endpoint Minio is reachable on. If Minio is

--- a/content/en/docs/setup/install/storage/oracle.md
+++ b/content/en/docs/setup/install/storage/oracle.md
@@ -5,8 +5,8 @@ sidebar:
   nav: setup
 ---
 
-Using [Oracle Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm){:target="\_blank"} as a storage source means that Spinnaker will store all of its persistent data in a
-[Bucket](https://docs.cloud.oracle.com/iaas/Content/Object/Tasks/managingbuckets.htm){:target="\_blank"}.
+Using [Oracle Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm) as a storage source means that Spinnaker will store all of its persistent data in a
+[Bucket](https://docs.cloud.oracle.com/iaas/Content/Object/Tasks/managingbuckets.htm).
 
 ## Prerequisites
 
@@ -14,45 +14,45 @@ If you have enabled [Oracle Cloud provider](/docs/setup/install/providers/oracle
 
 * A user in IAM for the person or system who will be using Spinnaker, and that user must be granted access to Object Storage or in one IAM group with permissions of Object Storage.
 
-   See [Adding Users](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/addingusers.htm){:target="\_blank"}, and [Object Storage Policy](https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/objectstoragepolicyreference.htm){:target="\_blank"}
+   See [Adding Users](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/addingusers.htm), and [Object Storage Policy](https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/objectstoragepolicyreference.htm)
 
 * The user's home region. 
 
-   See [Managing Regions](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingregions.htm){:target="\_blank"}. 
+   See [Managing Regions](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingregions.htm). 
    (e.g. `--region us-ashburn-1`)
    
 * RSA key pair in PEM format (minimum 2048 bits).
    
-   See [How to Generate an API Signing Key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How){:target="\_blank"}. 
+   See [How to Generate an API Signing Key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How). 
    (e.g. `--ssh-private-key-file-path /home/ubuntu/.oci/myPrivateKey.pem`)
    
 * Fingerprint of the public key. 
 
-   See [How to Get the Key's Fingerprint](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How3){:target="\_blank"}. 
+   See [How to Get the Key's Fingerprint](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How3). 
    (e.g. `--fingerprint 11:22:33:..:aa`)
    
 * Tenancy's OCID and user's OCID.
 
-   See [Where to Get the Tenancy's OCID and User's OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#Other){:target="\_blank"}. 
+   See [Where to Get the Tenancy's OCID and User's OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#Other). 
    (e.g. `--tenancyId ocid1.tenancy.oc1..aa... --user-id ocid1.user.oc1..aa...`)
    
 * Compartment OCID: On Oracle Cloud Console, open the navigation menu. Under Governance and Administration, go to Identity and click Compartments. 
    
-   See [Managing Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm){:target="\_blank"}. 
+   See [Managing Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm). 
    (e.g. `--compartment-id ocid1.compartment.oc1..aa...`)
    
 * Upload the public key from the key pair in the Console. 
    
-   See [How to Upload the Public Key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How2){:target="\_blank"}.
+   See [How to Upload the Public Key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#How2).
    
 * Namespace: this is your Tenancy name. On Oracle Cloud Console, click on the user menu. The Tenancy name is next to your user name. 
 
-   See [Object Storage Namespaces](https://docs.cloud.oracle.com/iaas/Content/Object/Tasks/understandingnamespaces.htm){:target="\_blank"}, and [Managing Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm){:target="\_blank"}. 
+   See [Object Storage Namespaces](https://docs.cloud.oracle.com/iaas/Content/Object/Tasks/understandingnamespaces.htm), and [Managing Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm). 
    (e.g. `--namespace my-tenancy`)
    
 * A bucket to store persistent data within the Object Storage namespace. If you do not already have a bucket that you want to use, Halyard will create one for you (either with the `--bucket-name` value provided, or `_spinnaker_front50_data` by default).
    
-   See [Managing Buckets](https://docs.cloud.oracle.com/iaas/Content/Object/Tasks/managingbuckets.htm){:target="\_blank"}. 
+   See [Managing Buckets](https://docs.cloud.oracle.com/iaas/Content/Object/Tasks/managingbuckets.htm). 
    (e.g. `--bucket-name my-spinnaker-bucket`) 
 
 ## Add Oracle Object Storage to Spinnaker

--- a/content/en/docs/setup/install/storage/s3.md
+++ b/content/en/docs/setup/install/storage/s3.md
@@ -7,9 +7,9 @@ aliases:
   - /setup/storage/s3/
 ---
 
-Using [S3](https://aws.amazon.com/s3/){:target="\_blank"} as a
+Using [S3](https://aws.amazon.com/s3/) as a
 storage source means that Spinnaker will store all of its persistent data in a
-[Bucket](https://aws.amazon.com/s3/details/){:target="\_blank"}.
+[Bucket](https://aws.amazon.com/s3/details/).
 
 > :warning: Alternatively, it is possible to use [Minio](/docs/setup/storage/minio)
 > instead of the real S3 if you are looking for a local persistant storage solution
@@ -17,11 +17,11 @@ storage source means that Spinnaker will store all of its persistent data in a
 
 ## Prerequisites
 
-You need an [AWS Account](https://aws.amazon.com/account/){:target="\_blank"},
+You need an [AWS Account](https://aws.amazon.com/account/),
 and a role or user configured with `s3` permissions.
 
 To grant a user or role `s3` permissions, refer to the
-[AWS documentation for creating roles for a user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user.html){:target="\_blank"},
+[AWS documentation for creating roles for a user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user.html),
 and make sure that both user and role policies grant access to “s3:\*”.
 
 If you are running Spinnaker on an EC2 instance, the instance profile of the instance

--- a/content/en/docs/setup/install/storage/storage-overview.md
+++ b/content/en/docs/setup/install/storage/storage-overview.md
@@ -13,7 +13,7 @@ in.
 Spinnaker supports the storage providers listed below. Whichever option you
 choose does not affect your choice of [Cloud Provider](/docs/v1.19/setup/providers/).
 That is, you can use [Google Cloud
-Storage](https://cloud.google.com/storage/){:target="\_blank"} as a storage
+Storage](https://cloud.google.com/storage/) as a storage
 source but still deploy to [Microsoft Azure](https://azure.microsoft.com/).
 
 ## Supported storage solutions

--- a/content/en/docs/setup/monitoring/_index.md
+++ b/content/en/docs/setup/monitoring/_index.md
@@ -19,9 +19,9 @@ in the sections [Consuming Metrics](#consuming-metrics) and in the
 [Monitoring Reference document](/reference/monitoring/).
 
 Spinnaker currently supports three specific third-party systems:
-[Prometheus](https://prometheus.io/){:target="\_blank"},
-[Datadog](https://www.datadoghq.com/){:target="\_blank"},
-and [Stackdriver](http://www.stackdriver.com/){:target="\_blank"}. The daemon is
+[Prometheus](https://prometheus.io/),
+[Datadog](https://www.datadoghq.com/),
+and [Stackdriver](http://www.stackdriver.com/). The daemon is
 extensible so that it should be straightforward to add other systems as well.
 In fact, each of the supported systems was provided using the daemon's extension
 mechanisms -- there are not "native" systems.

--- a/content/en/docs/setup/monitoring/datadog.md
+++ b/content/en/docs/setup/monitoring/datadog.md
@@ -7,7 +7,7 @@ sidebar:
 
 
 
-[Datadog](https://datadoghq.com){:target="\_blank"} is a modern monitoring &
+[Datadog](https://datadoghq.com) is a modern monitoring &
 analytics solution. This document describes how to configure Spinnaker and its
 monitoring daemon to publish metrics and dashboards to Datadog.
 
@@ -15,12 +15,12 @@ monitoring daemon to publish metrics and dashboards to Datadog.
 
 To get started, you'll need a Datadog account, API and App Keys. You can create
 API and App keys [here on the Datadog
-website](https://app.datadoghq.com/account/settings#api){:target="\_blank"}.
+website](https://app.datadoghq.com/account/settings#api).
 
 It is not required that you run a Datadog agent for this setup to work properly,
 but it is recommended to provide greater visibility into your spinnaker
 installation. If you do chose to run the agent, you can find more information on
-the the Datadog website here: [Agent - Datadog Docs](https://docs.datadoghq.com/agent/){:target="\_blank"}.
+the the Datadog website here: [Agent - Datadog Docs](https://docs.datadoghq.com/agent/).
 
 Additionally, you can install the agent with the `spinnaker-third-party` scripts as outlined below.
 This document assumes a debian installation.

--- a/content/en/docs/setup/monitoring/prometheus.md
+++ b/content/en/docs/setup/monitoring/prometheus.md
@@ -7,9 +7,9 @@ sidebar:
 
 
 
-[Prometheus](https://prometheus.io/){:target="\_blank"} is an open-source
+[Prometheus](https://prometheus.io/) is an open-source
 monitoring system that pairs nicely with Spinnaker. Prometheus does not have a
-native dashboard, rather it uses [Grafana](http://grafana.org){:target="\_blank"},
+native dashboard, rather it uses [Grafana](http://grafana.org),
 another open-source system. The Spinnaker integration bundles the two together,
 so as far as this document is concerned, Grafana and Prometheus are treated as
 one system.
@@ -26,7 +26,7 @@ The current Spinnaker installation script can configure for a simple
 single instance VM deployment typically used for prototype purposes, or
 a multi-VM "high-availability" production type deployment on Google Cloud
 Platform. For more information and custom configuration options, see the
-[Prometheus Configuration](https://prometheus.io/docs/operating/configuration/){:target="\_blank"}
+[Prometheus Configuration](https://prometheus.io/docs/operating/configuration/)
 documentation. They describe support for discovering services on EC2, Azure,
 and other platforms or discovery mechanisms you might be using.
 
@@ -133,8 +133,8 @@ run `hal deploy apply`.
        to discover the daemons running on GCE instances.
 
      * If you are deploying Spinnaker across multiple VMs on EC2,
-       see [Prometheus ec2_sd_config](https://prometheus.io/docs/operating/configuration/#<ec2_sd_config>){:target="\_blank"}.
-       If on Azure, see [Prometheus azure_sd_config](https://prometheus.io/docs/operating/configuration/#<azure_sd_config>){:target="\_blank"}.
+       see [Prometheus ec2_sd_config](https://prometheus.io/docs/operating/configuration/#<ec2_sd_config>).
+       If on Azure, see [Prometheus azure_sd_config](https://prometheus.io/docs/operating/configuration/#<azure_sd_config>).
        If you pursue one of these, please contribute back the work to
        improve the installer for those that follow your lead.
 

--- a/content/en/docs/setup/monitoring/stackdriver.md
+++ b/content/en/docs/setup/monitoring/stackdriver.md
@@ -24,7 +24,7 @@ With that said, *if you want to try it anyways*, below are instructions on how t
 
 ## Using Spinnaker for metric collection using Stackdriver Monitoring directly
 
-There are two ways to use [Stackdriver](https://cloud.google.com/stackdriver){:target="\_blank"}
+There are two ways to use [Stackdriver](https://cloud.google.com/stackdriver)
 with Spinnaker. The easiest is
 to configure Spinnaker microservices to push metrics directly into
 stackdriver. Additionally the Spinnaker Monitoring Daemon can write
@@ -42,7 +42,7 @@ Note that the current integration with Stackdriver is based on using
 custom metrics. All told there are a few hundred metrics and several
 thousand time series (exact numbers depend on individual circumstances).
 Custom metrics are considered a premium stackdriver feature and may incur
-[additional costs](https://cloud.google.com/stackdriver/pricing){:target="\_blank"}
+[additional costs](https://cloud.google.com/stackdriver/pricing)
 depending on your situation. If you are interested in using
 Stackdriver, please contact us through the Spinnaker Slack channel.
 
@@ -111,7 +111,7 @@ Proceed to [install the dashboards](#installing-the-stackdriver-dashboards)
 *__Note__: The Stackdriver Dashboard API is currently whitelisted, so
 you need a registered STACKDRIVER_API key in order to use it. If you
 are so inclined, [contact your sales
-representative](https://cloud.google.com/contact/){:target="\_blank"}.
+representative](https://cloud.google.com/contact/).
 
 To install the stackdriver dashboards, you need to have the monitoring daemon
 installed. But you only need it installed while you upload the dashboards.
@@ -126,7 +126,7 @@ sudo apt-get install spinnaker-monitoring-third-party -y
 ```
 
 With your browser, log into
-[app.google.stackdriver.com](https://app.google.stackdriver.com){:target="\_blank"}
+[app.google.stackdriver.com](https://app.google.stackdriver.com)
 and select your project. You should be able to see the various Spinnaker
 dashboards and select from them.
                                                                                                          
@@ -141,5 +141,5 @@ milliseconds or seconds.
 If you are using Stackdriver, you may wish to complement it with Datalab
 for the visualization or to manipulate the data. There are no datalab
 dashboards provided at present. See the
-[Google DataLab Website](https://cloud.google.com/datalab/){:target="\_blank"}
+[Google DataLab Website](https://cloud.google.com/datalab/)
 for more information.

--- a/content/en/docs/setup/quickstart/faq.md
+++ b/content/en/docs/setup/quickstart/faq.md
@@ -50,7 +50,7 @@ two solutions.
    and `hal config security api edit --override-base-url <full api url>`.
 
 2. If you don't want to rely on authentication, you can follow [this
-   guide](https://blog.spinnaker.io/exposing-spinnaker-to-end-users-4808bc936698){:target="\_blank"}.
+   guide](https://blog.spinnaker.io/exposing-spinnaker-to-end-users-4808bc936698).
    This makes sense if you're running Spinnaker in a private network, or have
    another form of authentication fronting Spinnaker.
 
@@ -70,7 +70,7 @@ Odds are Halyard can't connect to the configuration & version bucket (in Google
 Cloud Storage) it uses to determine if the configuration you've provided works
 for the version of Spinnaker you want to install. The bucket is
 `gs://halconfig`, see if you can reach it locally using the
-[`gsutil`](https://cloud.google.com/storage/docs/gsutil){:target="\_blank"} CLI.
+[`gsutil`](https://cloud.google.com/storage/docs/gsutil) CLI.
 The remediation will depend on your local network. You can also always omit
 validation with the `--no-validate` flag.
 
@@ -92,7 +92,7 @@ If this happens, there are one of two causes:
 
 First, please read the [custom configuration](/reference/halyard/custom/)
 documentation. With that in mind, if you're configuring any of Spinnaker's
-[Spring-based](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html){:target="\_blank"}
+[Spring-based](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html)
 services (everything but deck and spinnaker-monitoring), you're
 best off providing a `-local.yml` profile for the service in mind. For example,
 say you are configuring the Halyard
@@ -163,7 +163,7 @@ machines you care about.
 
 In the file under `/opt/halyard/bin/halyard`, add the necessary proxy
 configuration to the variable `DEFAULT_JVM_OPTS` as described
-[here](https://developers.google.com/gdata/articles/proxy_setup){:target="\_blank"}
+[here](https://developers.google.com/gdata/articles/proxy_setup)
 For example,
 ```bash
 DEFAULT_JVM_OPTS=-Dhttp.proxyHost=my.proxy.domain.com -Dhttp.proxyPort=3128
@@ -185,7 +185,7 @@ env:
 
 These settings will forward all external communication through the proxy server specified while
 keeping internal traffic non-proxied. Additional information can be found 
-[here.](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html){:target="\_blank"}
+[here.](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html)
 
 The Kubernetes provider must be handled differently. Because the Kubernetes provider 
 uses `kubectl` (which uses curl), you must set environment variables if you want 

--- a/content/en/docs/setup/security/authentication/index.md
+++ b/content/en/docs/setup/security/authentication/index.md
@@ -49,7 +49,7 @@ Getting the authentication working rarely happens on the first try. Each login a
  repository. Re-using these sessions is undesirable when testing configuration changes.
 
 We highly recommend using Google Chrome's [Incognito
-mode](https://support.google.com/chrome/answer/95464?source=gsearch&hl=en){:target="\_blank"}
+mode](https://support.google.com/chrome/answer/95464?source=gsearch&hl=en)
 when working with configuration changes.
 
 1. Open a new Incognito window.

--- a/content/en/docs/setup/security/authentication/ldap/index.md
+++ b/content/en/docs/setup/security/authentication/ldap/index.md
@@ -102,7 +102,7 @@ hal config security authn ldap enable
 You can also use `--user-search-base` (optional) and `--user-search-filter` if the simpler
 `--user-dn-pattern` does not match what your organization uses for `userDn`. We don't explore this
 use case here, but you can read up more on LDAP search filters
-[here](https://confluence.atlassian.com/kb/how-to-write-ldap-search-filters-792496933.html){:target="\_blank"}.
+[here](https://confluence.atlassian.com/kb/how-to-write-ldap-search-filters-792496933.html).
 
 
 ## Active Directory

--- a/content/en/docs/setup/security/authentication/x509/index.md
+++ b/content/en/docs/setup/security/authentication/x509/index.md
@@ -43,7 +43,7 @@ The certificates generated here only allow for the authentication of a user's id
 
 `roleOid` is used for this example.
 
-Client certificates with role information are parsed when roleOid is provided. This OID is configurable and is set via Halyard. The OID provided in the example below is defined [here](http://www.oid-info.com/cgi-bin/display?oid=1.2.840.10070.8.1&action=display){:target="\_blank"}.
+Client certificates with role information are parsed when roleOid is provided. This OID is configurable and is set via Halyard. The OID provided in the example below is defined [here](http://www.oid-info.com/cgi-bin/display?oid=1.2.840.10070.8.1&action=display).
 
 Encoding with any other OID can be done by editing the `openssl.conf`.
 
@@ -151,7 +151,7 @@ hal config security authn x509 edit --subject-principal-regex "EMAILADDRESS=(.*?
 By enabling X.509 on the main 8084 port, it causes the browser to ask the user to present their
 client certificate. Many end-users can get confused or annoyed by this message, so it is preferable to move this off of the main port.
 
-You can move the client certificate-enabled port by setting `default.apiPort` value to something other than 8084. This enables an additional port configuration that is [hardcoded](https://github.com/spinnaker/kork/blob/master/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfiguration.groovy){:target="\_blank"} to _need_ a valid X.509 certificate before allowing the request to proceed.
+You can move the client certificate-enabled port by setting `default.apiPort` value to something other than 8084. This enables an additional port configuration that is [hardcoded](https://github.com/spinnaker/kork/blob/master/kork-web/src/main/groovy/com/netflix/spinnaker/config/TomcatConfiguration.groovy) to _need_ a valid X.509 certificate before allowing the request to proceed.
 
 ## Workflow
 

--- a/content/en/docs/setup/security/authorization/github-teams/index.md
+++ b/content/en/docs/setup/security/authorization/github-teams/index.md
@@ -10,7 +10,7 @@ Roles from GitHub are mapped to the Teams under a specific GitHub organization.
 ## Personal Access Token
 
 1. Under an administrator's account, generate a new Personal Access Token from
-[https://github.com/settings/tokens](https://github.com/settings/tokens){:target="\_blank"}.
+[https://github.com/settings/tokens](https://github.com/settings/tokens).
 1. Give it a descriptive name such as "spinnaker-fiat."
 1. Select the `read:org` scope.
 1. Click "Generate Token"

--- a/content/en/docs/setup/security/authorization/google-groups/index.md
+++ b/content/en/docs/setup/security/authorization/google-groups/index.md
@@ -14,9 +14,9 @@ to manage the roles users are granted.
 In order to access a user's group membership, we must use the Google Admin Directory API. We will
 setup a Google Cloud Platform (GCP) service account and grant it access to the Directory API.
 
-1. Enable the Admin SDK [here](https://console.cloud.google.com/apis/library/admin.googleapis.com){:target="\_blank"}.
+1. Enable the Admin SDK [here](https://console.cloud.google.com/apis/library/admin.googleapis.com).
 
-1. In your [Cloud Console](https://console.cloud.google.com){:target="\_blank"},
+1. In your [Cloud Console](https://console.cloud.google.com),
 create a service account that will access the G Suite Directory API.
 
     ![creating a service account for Fiat in GCP console](fiat-service-account.png)
@@ -36,7 +36,7 @@ create a service account that will access the G Suite Directory API.
     ![View the client ID](fiat-cliend-id.png)
 
 1. Give your service account access to the G Suite Directory API in the
-[G Suite Admin console](https://admin.google.com){:target="\_blank"}.
+[G Suite Admin console](https://admin.google.com).
 
     ![authorize the service account to access the Directory API](fiat-authorize-client.png)
 

--- a/content/en/docs/setup/triggers/amazon.md
+++ b/content/en/docs/setup/triggers/amazon.md
@@ -7,11 +7,11 @@ sidebar:
 
 
 
-Spinnaker pipelines can be triggered from a queue in [Amazon Simple Queue Service (SQS)](https://aws.amazon.com/sqs/){:target="\_blank"} that receives new notifications from [Amazon Simple Notification Service (SNS)](https://aws.amazon.com/sns/){:target="\_blank"}.
+Spinnaker pipelines can be triggered from a queue in [Amazon Simple Queue Service (SQS)](https://aws.amazon.com/sqs/) that receives new notifications from [Amazon Simple Notification Service (SNS)](https://aws.amazon.com/sns/).
 
 # Prerequisites
 
-You need an AWS Account and the [AWS Command Line Interface (cli)](https://aws.amazon.com/cli/){:target="\_blank"} installed locally and configured with credentials that allow you to manage your AWS cloud resources.
+You need an AWS Account and the [AWS Command Line Interface (cli)](https://aws.amazon.com/cli/) installed locally and configured with credentials that allow you to manage your AWS cloud resources.
 
 ## Creating an Simple Notification Service (SNS) Topic
 

--- a/content/en/docs/setup/triggers/github/_index.md
+++ b/content/en/docs/setup/triggers/github/_index.md
@@ -6,7 +6,7 @@ description:
 ---
 
 Spinnaker can be configured to listen to changes to a repository in
-[GitHub](https://github.com){:target="\_blank"}. These steps show you how to
+[GitHub](https://github.com). These steps show you how to
 configure webhook push events to send to Spinnaker from a single GitHub repository.
 
 ## Prerequisites
@@ -22,7 +22,7 @@ configure webhook push events to send to Spinnaker from a single GitHub reposito
   [Halyard reference](/reference/halyard).
 
 * You need a [GitHub
-  repository](https://help.github.com/articles/create-a-repo/){:target="\_blank"}
+  repository](https://help.github.com/articles/create-a-repo/)
   to send Webhooks from.
 
 ## Configuring your GitHub webhook

--- a/content/en/docs/setup/triggers/google.md
+++ b/content/en/docs/setup/triggers/google.md
@@ -8,14 +8,14 @@ sidebar:
 
 
 Spinnaker pipelines can be triggered using a [Google Pub/Sub
-subscription](https://cloud.google.com/pubsub/docs/overview){:target="\_blank"}.
+subscription](https://cloud.google.com/pubsub/docs/overview).
 
 ## Prerequisites
 
-You need a [Google Cloud Platform](https://cloud.google.com/){:target="\_blank"}
+You need a [Google Cloud Platform](https://cloud.google.com/)
 (GCP) project to with the [Pub/Sub API
-enabled](https://pantheon.corp.google.com/apis/api/pubsub.googleapis.com){:target="\_blank"},
-and [`gcloud`](https://cloud.google.com/sdk/downloads){:target="\_blank"}
+enabled](https://pantheon.corp.google.com/apis/api/pubsub.googleapis.com),
+and [`gcloud`](https://cloud.google.com/sdk/downloads)
 installed locally.  You can check that `gcloud` is installed and authenticated
 by running:
 
@@ -30,8 +30,8 @@ The Pub/Sub integration can be used to either:
 * Start pipelines by sending Pub/Sub messages from a system you own.
 
 * Start pipelines using Pub/Sub messages originating from a Google Cloud
-  system, such as [Google Cloud Storage](https://cloud.google.com/storage/){:target="\_blank"},
-  or [Google Container Registry](https://cloud.google.com/container-registry/){:target="\_blank"}.
+  system, such as [Google Cloud Storage](https://cloud.google.com/storage/),
+  or [Google Container Registry](https://cloud.google.com/container-registry/).
 
 Configuration and setup for all cases are described below.
 
@@ -60,7 +60,7 @@ gcloud beta pubsub subscriptions create $SUBSCRIPTION --topic $TOPIC
 ```
 
 At this point, you can use the [publisher
-guide](https://cloud.google.com/pubsub/docs/publisher){:target="\_blank"} to
+guide](https://cloud.google.com/pubsub/docs/publisher) to
 learn how to publish messages programmatically to the topic you have created.
 
 Note that your topic messages need to be valid JSON, otherwise an exception
@@ -92,7 +92,7 @@ gcloud beta pubsub subscriptions create $SUBSCRIPTION --topic $TOPIC
 
 To understand the format that GCS will publish messages in, please read the
 [reference
-material](https://cloud.google.com/storage/docs/pubsub-notifications){:target="\_blank"}.
+material](https://cloud.google.com/storage/docs/pubsub-notifications).
 
 ### Receiving messages from Google Container Registry (GCR)
 
@@ -127,12 +127,12 @@ gcloud beta pubsub subscriptions create $SUBSCRIPTION \
 
 To understand the format that GCR will publish messages in, please read the
 [reference
-material](https://cloud.google.com/container-registry/docs/configuring-notifications){:target="\_blank"}.
+material](https://cloud.google.com/container-registry/docs/configuring-notifications).
 
 ## Credentials
 
 Spinnaker needs a [service
-account](https://cloud.google.com/compute/docs/access/service-accounts){:target="\_blank"} to
+account](https://cloud.google.com/compute/docs/access/service-accounts) to
 authenticate as against GCP, with the `roles/pubsub.subscriber` role enabled. If
 you don't already have such a service account with the corresponding JSON key
 downloaded, you can run the following commands to do so:

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,2 @@
+<!-- configures external links to open a new tab -->
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text }}</a>


### PR DESCRIPTION
- Sets goldmark as the markdown renderer explicitly and comment out black friday. 
- Uses the default goldmark config suggestions from Hugo
- Adds `/_layouts/_default/_markup/render-link.html` which configures external links to open in a new tab, replacing the unsupported `{:target="\_blank"}`
- Removes every instance of `{:target="\_blank"}`