### PR TITLE
docs(seo): add logic to generate meta "description" tag

### DIFF
--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -2,3 +2,9 @@
 <!-- stylesheet for algolia docsearch -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 {{ end }}
+{{ if .Page.Description }}
+  <meta name="description" content="{{ .Page.Description }}">
+{{ else }}
+  {{ $desc := (.Page.Content | safeHTML | truncate 150) }}
+  <meta name="description" content="{{ $desc }}">
+{{ end }}


### PR DESCRIPTION
Bootstrap and Docsy generate the meta description tag as `meta itemprop="description" content="page description"` but search engines look for `meta name='description' ...`. This is a workaround until the issue is 
 addressed by the underlying frameworks.

I traced the meta tags definitions to `themes/docsy/assets/vendor/bootstrap/site/_includes/header.html`. Emailed the Docsy users list asking why` <meta name="description"` is generated as `<meta itemprop="description"'` but haven't had a response. For SEO, add correct `<meta name="description"` to `layouts/partials/hooks/head-end.html`. 

To test, do a "view page source" in your browser and look for `<meta name="description"`. If the page contains `description` in the front matter, that is used for content. Otherwise, the value for "content" comes from the `.Page.Content` truncated to first 150 characters.