### PR TITLE
fix(docs): Remove Alpha comments from MD overview

### DIFF
--- a/content/en/docs/guides/user/managed-delivery/managed-delivery-overview.md
+++ b/content/en/docs/guides/user/managed-delivery/managed-delivery-overview.md
@@ -7,13 +7,6 @@ description: >
 ---
 
 
-{{< alpha version="1.18" >}}
-
-> Managed Delivery is currently in Alpha and is not recommended for managing
-mission-critical production services. Only EC2 and Titus cloud providers are
-currently supported and many features are still in flux or pending.
-
-
 ## What is Managed Delivery?
 
 Managed Delivery is an initiative with two key goals.


### PR DESCRIPTION
Managed Delivery hasn't been in Alpha for more than a year now. We're running it in production at Netflix for hundreds of apps. Just correcting the docs to reflect that.