### PR TITLE
docs(site): Fix logic error

### DIFF
--- a/layouts/partials/hero-homepage.html
+++ b/layouts/partials/hero-homepage.html
@@ -7,7 +7,7 @@
         {{.Params.subtitle}}<br />
        <small>{{.Params.subtitle_1}}</small> 
       </h3>
-      {{ with .Params.news_banner }}
+      {{ if .Params.news_banner }}
       <a href="{{.Params.news_link}}">
         <h4>
           {{.Params.news_text}}


### PR DESCRIPTION
I corrected a line that had `when` instead of `if`. Before the correction, the site wouldn't compile if `.Params.news_link` was defined.