### PR TITLE
docs(fix): add redirect from old URL

### DIFF
--- a/content/en/docs/guides/user/pipeline/expressions/_index.md
+++ b/content/en/docs/guides/user/pipeline/expressions/_index.md
@@ -4,6 +4,8 @@ linkTitle: "Pipeline Expressions Guide"
 weight: 10
 description: >
   Dynamically set and access variables during pipeline execution.
+aliases:
+  - /guides/user/pipeline-expressions/
 ---
 
 Pipeline expressions allow you to dynamically set and access variables during


### PR DESCRIPTION
The page was renamed in the move. Added redirect for `/guides/user/pipeline-expressions/`