### PR TITLE
Add example for service-account,yaml

### DIFF
--- a/content/en/docs/setup/install/providers/kubernetes-v2/aws-eks.md
+++ b/content/en/docs/setup/install/providers/kubernetes-v2/aws-eks.md
@@ -138,9 +138,19 @@ Next, create a service account for the Amazon EKS cluster:
 kubectl apply --context $CONTEXT -f {{< link "downloads/kubernetes/service-account.yml">}}
 ```
 
-See the [Kubernetes documentation for more details on service accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/).
+A minimal example for `service-account.yaml` would look something like this:
 
-Extract the secret token of the `spinnaker-service-account`:
+```YAML
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spinnaker-service-account
+  namespace: spinnaker
+```
+
+Note that this requires an existing `spinnaker` namespace. For [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) bindings in addition to the service account, see [Optional: Configure Kubernetes roles (RBAC)](https://spinnaker.io/docs/setup/install/providers/kubernetes-v2/#optional-configure-kubernetes-roles-rbac). In general, see the [Kubernetes documentation for more details on service accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/).
+
+Extract the secret token of the created `spinnaker-service-account`:
 
 ```
 TOKEN=$(kubectl get secret --context $CONTEXT \

--- a/content/en/docs/setup/install/providers/kubernetes-v2/aws-eks.md
+++ b/content/en/docs/setup/install/providers/kubernetes-v2/aws-eks.md
@@ -138,7 +138,7 @@ Next, create a service account for the Amazon EKS cluster:
 kubectl apply --context $CONTEXT -f {{< link "downloads/kubernetes/service-account.yml">}}
 ```
 
-A minimal example for `service-account.yaml` would look something like this:
+A minimal example for `service-account.yaml` looks like this:
 
 ```YAML
 apiVersion: v1
@@ -148,7 +148,7 @@ metadata:
   namespace: spinnaker
 ```
 
-Note that this requires an existing `spinnaker` namespace. For [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) bindings in addition to the service account, see [Optional: Configure Kubernetes roles (RBAC)](https://spinnaker.io/docs/setup/install/providers/kubernetes-v2/#optional-configure-kubernetes-roles-rbac). In general, see the [Kubernetes documentation for more details on service accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/).
+Note that this requires an existing `spinnaker` namespace. For [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) bindings in addition to the service account, see [Optional: Configure Kubernetes roles (RBAC)](https://spinnaker.io/docs/setup/install/providers/kubernetes-v2/#optional-configure-kubernetes-roles-rbac). See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) for more details on service accounts.
 
 Extract the secret token of the created `spinnaker-service-account`:
 


### PR DESCRIPTION
The service-account.yaml file is referred to but there is no mention of what it should actually contain. This is not very complex, but it very much breaks the flow of the install and causes you to have to break out and look up the correct syntax for a service account, whether it requires RBAC etc. 

Added a link to the RBAC notes also to help on that front.