### PR TITLE
Fix e-mail table on Notifications page

### DIFF
--- a/content/en/docs/setup/other_config/features/notifications/index.md
+++ b/content/en/docs/setup/other_config/features/notifications/index.md
@@ -44,6 +44,7 @@ Email in spinnaker is provided by [Spring Boot Mail
 starter](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-email.html).
 
 The settings for some popular email providers are listed below:
+
 Email Provider | SMTP username | SMTP password | SMTP server address | SMTP port (TLS) | SMTP port (SSL) | SMTP TLS/SSL required 
 ------ | ------ | ------ | ------ | ------ | ------ | ------ 
 Gsuite/Gmail | Your email address | Your email password | smtp.gmail.com | 587 | 465 | yes 


### PR DESCRIPTION
On the notifications page, the Generated e-mail table isn't displaying on the generated output, nor in raw Markdown. Little whitespace fix should fix the table.

Source: https://spinnaker.io/docs/setup/other_config/features/notifications/#email

**Generated with bug:**
<img width="400" alt="image" src="https://user-images.githubusercontent.com/33203301/131936982-48380a56-24b0-4d53-a445-bb33ebf5e368.png">

| Before | After
| --- | --- |
| <img width="1255" alt="image" src="https://user-images.githubusercontent.com/33203301/131937047-57ec07e3-4afb-4341-839b-7ada20a67bd2.png"> | <img width="984" alt="image" src="https://user-images.githubusercontent.com/33203301/131937318-36c10724-a1d8-4439-a5f2-46fdb7ec668f.png"> |