### PR TITLE
Corrected misspelling of "continuous" in travis.md

### DIFF
--- a/content/en/docs/setup/other_config/ci/travis.md
+++ b/content/en/docs/setup/other_config/ci/travis.md
@@ -1,7 +1,7 @@
 ---
 
 title:  "Travis CI"
-description: Spinnaker supports Travis as a continuou integration system.
+description: Spinnaker supports Travis as a continuous integration system.
 ---
 
 You can configure Spinnaker to use [Travis


### PR DESCRIPTION
Corrected misspelling of "continuous"