### PR TITLE
Extend Kubernetes role to cover statefulsets

### DIFF
--- a/content/en/docs/setup/install/providers/kubernetes-v2/_index.md
+++ b/content/en/docs/setup/install/providers/kubernetes-v2/_index.md
@@ -127,10 +127,10 @@ rules:
     resources: ['horizontalpodautoscalers']
     verbs: ['list', 'get']
   - apiGroups: ['apps']
-    resources: ['controllerrevisions', 'statefulsets']
+    resources: ['controllerrevisions']
     verbs: ['list']
   - apiGroups: ['extensions', 'apps']
-    resources: ['deployments', 'replicasets', 'ingresses']
+    resources: ['daemonsets', 'deployments', 'deployments/scale', 'ingresses', 'replicasets', 'statefulsets']
     verbs:
       [
         'create',

--- a/content/en/docs/setup/install/providers/kubernetes-v2/k8s-provider.md
+++ b/content/en/docs/setup/install/providers/kubernetes-v2/k8s-provider.md
@@ -114,10 +114,10 @@ rules:
   resources: ["horizontalpodautoscalers"]
   verbs: ["list", "get"]
 - apiGroups: ["apps"]
-  resources: ["controllerrevisions", "statefulsets"]
+  resources: ["controllerrevisions"]
   verbs: ["list"]
 - apiGroups: ["extensions", "apps"]
-  resources: ["deployments", "deployments/scale", "replicasets", "ingresses"]
+  resources: ["daemonsets", "deployments", "deployments/scale", "ingresses", "replicasets", "statefulsets"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
 # These permissions are necessary for halyard to operate. We use this role also to deploy Spinnaker itself.
 - apiGroups: [""]

--- a/content/en/docs/setup/install/providers/kubernetes.md
+++ b/content/en/docs/setup/install/providers/kubernetes.md
@@ -134,10 +134,10 @@ rules:
   resources: ["horizontalpodautoscalers"]
   verbs: ["list", "get"]
 - apiGroups: ["apps"]
-  resources: ["controllerrevisions", "statefulsets"]
+  resources: ["controllerrevisions"]
   verbs: ["list"]
-- apiGroups: ["extensions", "app", "apps"]
-  resources: ["deployments", "replicasets", "ingresses", "daemonsets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["daemonsets", "deployments", "deployments/scale", "ingresses", "replicasets", "statefulsets"]
   verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
After adding a statefulset application, I realized on the clusters page that I cannot open the details panel. It's because the endpoint (`https://spinnaker/manifests/de-prod/auth/statefulSet%20app-name`) returns 403 Forbidden.

```
{
  "timestamp": 1633679782550,
  "status": 403,
  "error": "Forbidden",
  "message": "403 ",
  "body": "{\"error\":\"Forbidden\",\"message\":\"Access is denied\",\"status\":403,\"timestamp\":\"2021-10-08T07:56:22.542+00:00\"}",
  "url": "http://spin-clouddriver.platform:7002/manifests/de-prod/auth/statefulSet%20app-name"
}
```

This PR extends the role to cover stateful set actions.

And while there,
* Aligns resources under `apps` and `extensions` API groups.
* Drops unnecessary `app` API Group.