### PR TITLE
docs(fix): Updated typo from nodeSelectors to nodeSelector

### DIFF
--- a/content/en/docs/reference/halyard/custom.md
+++ b/content/en/docs/reference/halyard/custom.md
@@ -169,10 +169,10 @@ Node selector annotations will put out `nodeSelector` values in the Pod specific
 
 ```
 kubernetes:
-  nodeSelectors:
+  nodeSelector:
      exampleNodeKey: exampleNodeValue
   deploymentEnvironment:
-    nodeSelectors:
+    nodeSelector:
       exampleNodeKey: exampleNodeValue
 ```
 


### PR DESCRIPTION
The field nodeSelectors does not propagate the changes to the pod. Per the kubernetes docs, the field is nodeSelector: and not nodeSelectors:. Suggesting this change after testing it out.