### PR TITLE
docs(jenkins): fix Jenkins installation info

### DIFF
--- a/content/en/docs/guides/tutorials/codelabs/hello-deployment/index.md
+++ b/content/en/docs/guides/tutorials/codelabs/hello-deployment/index.md
@@ -26,7 +26,7 @@ image. Spinnaker expects all applications to be deployed as deb packages.
 
 If you already have a Jenkins server, you can skip this step.
 
-Please refer to the instruction at http://pkg.jenkins-ci.org/debian/ for updated commands(In the event you run into issues )
+In the event you run into issues with these example commands, refer to the instructions at http://pkg.jenkins-ci.org/debian/ for updated commands.
 
 SSH into your instance and run the following:
 


### PR DESCRIPTION
Using the previous instructions Jenkins was failing to build with the following error
ubuntu@ip-172-31-27-140:~$ sudo apt-get update
Hit:1 http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal InRelease
Hit:2 http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:3 http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal-backports InRelease                                
Hit:4 http://security.ubuntu.com/ubuntu focal-security InRelease                                              
Ign:5 http://pkg.jenkins-ci.org/debian binary/ InRelease                                
Get:6 http://pkg.jenkins-ci.org/debian binary/ Release [2044 B]
Get:7 http://pkg.jenkins-ci.org/debian binary/ Release.gpg [833 B]
0% [Working]                       
Ign:7 http://pkg.jenkins-ci.org/debian binary/ Release.gpg
Reading package lists... Done
W: GPG error: http://pkg.jenkins-ci.org/debian binary/ Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY FCEF32E745F2C3D5
E: The repository 'http://pkg.jenkins-ci.org/debian binary/ Release' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.


On looking at the documentation they had new instructions.

- Updated the instructions
- Also added a link to the jenkins page, just in case in the future if they changes