### PR TITLE
Update docs/setup/other_config/spin/index.md

### DIFF
--- a/content/en/docs/setup/other_config/spin/index.md
+++ b/content/en/docs/setup/other_config/spin/index.md
@@ -26,11 +26,7 @@ sudo mv spin /usr/local/bin/spin
 ### On MacOS
 
 ```bash
-curl -LO https://storage.googleapis.com/spinnaker-artifacts/spin/$(curl -s https://storage.googleapis.com/spinnaker-artifacts/spin/latest)/darwin/amd64/spin
-
-chmod +x spin
-
-sudo mv spin /usr/local/bin/spin
+brew install spin
 ```
 
 ### On Windows
@@ -147,8 +143,8 @@ auth:
     - scope1
     - scope2
     cachedToken:
-      accesstoken: ${ACCESS_TOKEN} # Note the key capitalization
-      refreshtoken: ${REFRESH_TOKEN} # Note the key capitalization
+      access_token: ${ACCESS_TOKEN} # Note the key capitalization
+      refresh_token: ${REFRESH_TOKEN} # Note the key capitalization
 ```
 
 This method is OAuth2-provider specific since the workflow to acquire


### PR DESCRIPTION
1. installation with `curl` is not working because the artifact is not available
2. in the `auth.oauth2.cachedToken` fields were defined incorrectly
    - https://github.com/spinnaker/spin/blob/180bc8c2923423e61a9a0431b52abfceca7cfbe1/config/auth/oauth2/config.go#L29 
    - https://cs.opensource.google/go/x/oauth2/+/d3ed0bb2:token.go;l=31