### PR TITLE
doc(fix/kork): Update instructions to build and use kork in local development.

### DIFF
--- a/content/en/docs/community/contributing/code/developer-guides/dev-env/kork-library.md
+++ b/content/en/docs/community/contributing/code/developer-guides/dev-env/kork-library.md
@@ -15,8 +15,8 @@ description: >
 ### Kork
 
 1. Make desired changes to `kork` module locally.
-2. Invoke `$ ./gradlew -PenablePublishing=true publishToMavenLocal`.
-3. Make note of the version printed:
+2. Invoke `$ ./gradlew -PenablePublishing=true -Pversion=0.1.0-SNAPSHOT publishToMavenLocal`.
+3. Make note of the version:
 
 ```
 $ ./gradlew -PenablePublishing=true publishToMavenLocal
@@ -39,7 +39,7 @@ repositories {
 
     ```
     eachDependency {
-      if (it.requested.group == 'com.netflix.spinnaker.kork') it.useVersion '0.1.0-SNAPSHOT'
+      if (it.requested.group == 'io.spinnaker.kork') it.useVersion '0.1.0-SNAPSHOT'
     }
     ```
 


### PR DESCRIPTION
The group id of kork has been changed from com.netflix.spinnaker.kork to io.spinnaker.kork in [this commit ](https://github.com/spinnaker/kork/commit/1d46c68eb50e7cc109f94930c421aa3c8a623350#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7R29)but the same is not reflecting in the documentation hence this PR. Also updated gradlew command to include version.  