### PR TITLE
docs(fix): Update Keel port

### DIFF
--- a/content/en/docs/reference/architecture/microservices-overview.md
+++ b/content/en/docs/reference/architecture/microservices-overview.md
@@ -141,4 +141,4 @@ By default Spinnaker binds ports according to the following table
 | Kayenta     | 8090 |
 | Orca        | 8083 |
 | Rosco       | 8087 |
-| Keel        | 8087              |
+| Keel        | 7010 |


### PR DESCRIPTION
The Keel port has been updated to 7010 (see PR links below).
Update the Keel port in the docs.

See:
https://github.com/spinnaker/keel/pull/1410
https://github.com/spinnaker/kustomization-base/pull/32