### PR TITLE
docs(versions): Automatically determine latest stable & deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ themes/**
 .netlify
 
 .idea/
+
+.hugo_build.lock

--- a/content/en/changelogs/1.0.0-changelog.md
+++ b/content/en/changelogs/1.0.0-changelog.md
@@ -5,7 +5,6 @@ date: 2017-06-05 11:21:34 -0400
 tags:
   - changelogs
   - 1.0
-  - deprecated
 ---
 
 - Initial release

--- a/content/en/changelogs/1.0.1-changelog.md
+++ b/content/en/changelogs/1.0.1-changelog.md
@@ -5,7 +5,6 @@ date: 2017-06-12 20:33:32
 tags:
   - changelogs
   - 1.0
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/b3515a47abbcdc86f0cfdc2bd6cb8a17.js"></script>

--- a/content/en/changelogs/1.1.0-changelog.md
+++ b/content/en/changelogs/1.1.0-changelog.md
@@ -5,7 +5,6 @@ date: 2017-07-05 18:47:56
 tags:
   - changelogs
   - 1.1
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/1b02cdba17f78c3dc9f4210d09610ac8.js"></script>

--- a/content/en/changelogs/1.1.1-changelog.md
+++ b/content/en/changelogs/1.1.1-changelog.md
@@ -5,7 +5,6 @@ date: 2017-07-21 13:35:55
 tags:
   - changelogs
   - 1.1
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/d223113b2967deb1272b5f8bffa7645a.js"></script>

--- a/content/en/changelogs/1.1.2-changelog.md
+++ b/content/en/changelogs/1.1.2-changelog.md
@@ -5,7 +5,6 @@ date: 2017-07-27 21:42:06
 tags:
   - changelogs
   - 1.1
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/83f03c39840317b473893da6abea7a0e.js"></script>

--- a/content/en/changelogs/1.10.0-changelog.md
+++ b/content/en/changelogs/1.10.0-changelog.md
@@ -5,7 +5,6 @@ date: 2018-10-16 17:31:38
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.0
 ---
 

--- a/content/en/changelogs/1.10.1-changelog.md
+++ b/content/en/changelogs/1.10.1-changelog.md
@@ -5,7 +5,6 @@ date: 2018-10-24 13:04:45
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.1
 ---
 

--- a/content/en/changelogs/1.10.10-changelog.md
+++ b/content/en/changelogs/1.10.10-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-11 21:23:16
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.10
 ---
 

--- a/content/en/changelogs/1.10.11-changelog.md
+++ b/content/en/changelogs/1.10.11-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-15 08:41:34
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.11
 ---
 

--- a/content/en/changelogs/1.10.12-changelog.md
+++ b/content/en/changelogs/1.10.12-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-22 17:55:10
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.12
 ---
 

--- a/content/en/changelogs/1.10.13-changelog.md
+++ b/content/en/changelogs/1.10.13-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-30 18:25:40
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.13
 ---
 

--- a/content/en/changelogs/1.10.14-changelog.md
+++ b/content/en/changelogs/1.10.14-changelog.md
@@ -5,7 +5,6 @@ date: 2019-03-01 12:43:49
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.14
 ---
 

--- a/content/en/changelogs/1.10.2-changelog.md
+++ b/content/en/changelogs/1.10.2-changelog.md
@@ -5,7 +5,6 @@ date: 2018-11-05 09:38:18
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.2
 ---
 

--- a/content/en/changelogs/1.10.3-changelog.md
+++ b/content/en/changelogs/1.10.3-changelog.md
@@ -5,7 +5,6 @@ date: 2018-11-09 13:55:08
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.3
 ---
 

--- a/content/en/changelogs/1.10.4-changelog.md
+++ b/content/en/changelogs/1.10.4-changelog.md
@@ -5,7 +5,6 @@ date: 2018-11-12 14:27:04
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.4
 ---
 

--- a/content/en/changelogs/1.10.5-changelog.md
+++ b/content/en/changelogs/1.10.5-changelog.md
@@ -5,7 +5,6 @@ date: 2018-11-15 16:46:26
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.5
 ---
 

--- a/content/en/changelogs/1.10.6-changelog.md
+++ b/content/en/changelogs/1.10.6-changelog.md
@@ -5,7 +5,6 @@ date: 2018-12-19 08:00:48
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.6
 ---
 

--- a/content/en/changelogs/1.10.7-changelog.md
+++ b/content/en/changelogs/1.10.7-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-03 09:58:06
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.7
 ---
 

--- a/content/en/changelogs/1.10.8-changelog.md
+++ b/content/en/changelogs/1.10.8-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-04 09:24:12
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.8
 ---
 

--- a/content/en/changelogs/1.10.9-changelog.md
+++ b/content/en/changelogs/1.10.9-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-05 12:44:19
 tags:
   - changelogs
   - 1.10
-  - deprecated
 version: 1.10.9
 ---
 

--- a/content/en/changelogs/1.11.0-changelog.md
+++ b/content/en/changelogs/1.11.0-changelog.md
@@ -5,7 +5,6 @@ date: 2018-12-13 14:49:42
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.0
 ---
 

--- a/content/en/changelogs/1.11.1-changelog.md
+++ b/content/en/changelogs/1.11.1-changelog.md
@@ -5,7 +5,6 @@ date: 2018-12-19 11:44:31
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.1
 ---
 

--- a/content/en/changelogs/1.11.10-changelog.md
+++ b/content/en/changelogs/1.11.10-changelog.md
@@ -5,7 +5,6 @@ date: 2019-02-25 15:39:58
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.10
 ---
 

--- a/content/en/changelogs/1.11.11-changelog.md
+++ b/content/en/changelogs/1.11.11-changelog.md
@@ -5,7 +5,6 @@ date: 2019-03-01 12:46:48
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.11
 ---
 

--- a/content/en/changelogs/1.11.12-changelog.md
+++ b/content/en/changelogs/1.11.12-changelog.md
@@ -5,7 +5,6 @@ date: 2019-04-05 10:55:49
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.12
 ---
 

--- a/content/en/changelogs/1.11.13-changelog.md
+++ b/content/en/changelogs/1.11.13-changelog.md
@@ -5,7 +5,6 @@ date: 2019-05-01 10:38:14
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.13
 ---
 

--- a/content/en/changelogs/1.11.2-changelog.md
+++ b/content/en/changelogs/1.11.2-changelog.md
@@ -5,7 +5,6 @@ date: 2018-12-21 10:49:22
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.2
 ---
 

--- a/content/en/changelogs/1.11.3-changelog.md
+++ b/content/en/changelogs/1.11.3-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-03 09:36:38
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.3
 ---
 

--- a/content/en/changelogs/1.11.4-changelog.md
+++ b/content/en/changelogs/1.11.4-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-05 09:17:34
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.4
 ---
 

--- a/content/en/changelogs/1.11.5-changelog.md
+++ b/content/en/changelogs/1.11.5-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-11 17:45:29
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.5
 ---
 

--- a/content/en/changelogs/1.11.6-changelog.md
+++ b/content/en/changelogs/1.11.6-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-15 07:29:43
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.6
 ---
 

--- a/content/en/changelogs/1.11.7-changelog.md
+++ b/content/en/changelogs/1.11.7-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-22 18:38:07
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.7
 ---
 

--- a/content/en/changelogs/1.11.8-changelog.md
+++ b/content/en/changelogs/1.11.8-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-28 15:33:55
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.8
 ---
 

--- a/content/en/changelogs/1.11.9-changelog.md
+++ b/content/en/changelogs/1.11.9-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-30 18:27:42
 tags:
   - changelogs
   - 1.11
-  - deprecated
 version: 1.11.9
 ---
 

--- a/content/en/changelogs/1.12.0-changelog.md
+++ b/content/en/changelogs/1.12.0-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-28 17:13:47
 tags:
   - chagelogs
   - 1.12
-  - deprecated
 version: 1.12.0
 ---
 

--- a/content/en/changelogs/1.12.1-changelog.md
+++ b/content/en/changelogs/1.12.1-changelog.md
@@ -5,7 +5,6 @@ date: 2019-01-31 17:01:57
 tags:
   - chagelogs
   - 1.12
-  - deprecated
 version: 1.12.1
 ---
 

--- a/content/en/changelogs/1.12.10-changelog.md
+++ b/content/en/changelogs/1.12.10-changelog.md
@@ -5,7 +5,6 @@ date: 2019-04-29 11:39:22
 tags:
   - changelogs
   - 1.12
-  - deprecated
 version: 1.12.10
 ---
 

--- a/content/en/changelogs/1.12.11-changelog.md
+++ b/content/en/changelogs/1.12.11-changelog.md
@@ -5,7 +5,6 @@ date: 2019-05-23 15:17:25
 tags:
   - changelogs
   - 1.12
-  - deprecated
 version: 1.12.11
 ---
 

--- a/content/en/changelogs/1.12.12-changelog.md
+++ b/content/en/changelogs/1.12.12-changelog.md
@@ -5,7 +5,6 @@ date: 2019-06-05 14:46:51
 tags:
   - changelogs
   - 1.12
-  - deprecated
 version: 1.12.12
 ---
 

--- a/content/en/changelogs/1.12.13-changelog.md
+++ b/content/en/changelogs/1.12.13-changelog.md
@@ -5,7 +5,6 @@ date: 2019-06-20 11:12:30
 tags:
   - changelogs
   - 1.12
-  - deprecated
 version: 1.12.13
 ---
 

--- a/content/en/changelogs/1.12.14-changelog.md
+++ b/content/en/changelogs/1.12.14-changelog.md
@@ -5,7 +5,6 @@ date: 2019-07-08 10:47:01
 tags:
   - changelogs
   - 1.12
-  - deprecated
 version: 1.12.14
 ---
 

--- a/content/en/changelogs/1.12.2-changelog.md
+++ b/content/en/changelogs/1.12.2-changelog.md
@@ -5,7 +5,6 @@ date: 2019-02-14 16:17:05
 tags:
   - chagelogs
   - 1.12
-  - deprecated
 version: 1.12.2
 ---
 

--- a/content/en/changelogs/1.12.3-changelog.md
+++ b/content/en/changelogs/1.12.3-changelog.md
@@ -5,7 +5,6 @@ date: 2019-02-25 15:41:45
 tags:
   - chagelogs
   - 1.12
-  - deprecated
 version: 1.12.3
 ---
 

--- a/content/en/changelogs/1.12.4-changelog.md
+++ b/content/en/changelogs/1.12.4-changelog.md
@@ -5,7 +5,6 @@ date: 2019-03-01 12:55:24
 tags:
   - chagelogs
   - 1.12
-  - deprecated
 version: 1.12.4
 ---
 

--- a/content/en/changelogs/1.12.5-changelog.md
+++ b/content/en/changelogs/1.12.5-changelog.md
@@ -5,7 +5,6 @@ date: 2019-03-08 19:43:23
 tags:
   - chagelogs
   - 1.12
-  - deprecated
 version: 1.12.5
 ---
 

--- a/content/en/changelogs/1.12.6-changelog.md
+++ b/content/en/changelogs/1.12.6-changelog.md
@@ -5,7 +5,6 @@ date: 2019-03-13 22:37:28
 tags:
   - changelogs
   - 1.12
-  - deprecated
 version: 1.12.6
 ---
 

--- a/content/en/changelogs/1.12.7-changelog.md
+++ b/content/en/changelogs/1.12.7-changelog.md
@@ -5,7 +5,6 @@ date: 2019-03-22 10:16:58
 tags:
   - changelogs
   - 1.12
-  - deprecated
 version: 1.12.7
 ---
 

--- a/content/en/changelogs/1.12.8-changelog.md
+++ b/content/en/changelogs/1.12.8-changelog.md
@@ -5,7 +5,6 @@ date: 2019-04-01 09:48:34
 tags:
   - changelogs
   - 1.12
-  - deprecated
 version: 1.12.8
 ---
 

--- a/content/en/changelogs/1.12.9-changelog.md
+++ b/content/en/changelogs/1.12.9-changelog.md
@@ -5,7 +5,6 @@ date: 2019-04-05 10:11:53
 tags:
   - changelogs
   - 1.12
-  - deprecated
 version: 1.12.9
 ---
 

--- a/content/en/changelogs/1.13.0-changelog.md
+++ b/content/en/changelogs/1.13.0-changelog.md
@@ -5,7 +5,6 @@ date: 2019-03-25 15:38:07
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.0
 ---
 

--- a/content/en/changelogs/1.13.1-changelog.md
+++ b/content/en/changelogs/1.13.1-changelog.md
@@ -5,7 +5,6 @@ date: 2019-04-09 10:31:22
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.1
 ---
 

--- a/content/en/changelogs/1.13.10-changelog.md
+++ b/content/en/changelogs/1.13.10-changelog.md
@@ -5,7 +5,6 @@ date: 2019-06-20 11:31:40
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.10
 ---
 

--- a/content/en/changelogs/1.13.11-changelog.md
+++ b/content/en/changelogs/1.13.11-changelog.md
@@ -5,7 +5,6 @@ date: 2019-07-08 09:56:56
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.11
 ---
 

--- a/content/en/changelogs/1.13.12-changelog.md
+++ b/content/en/changelogs/1.13.12-changelog.md
@@ -5,7 +5,6 @@ date: 2019-07-29 14:19:09
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.12
 ---
 

--- a/content/en/changelogs/1.13.2-changelog.md
+++ b/content/en/changelogs/1.13.2-changelog.md
@@ -5,7 +5,6 @@ date: 2019-04-05 11:46:16
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.2
 ---
 

--- a/content/en/changelogs/1.13.3-changelog.md
+++ b/content/en/changelogs/1.13.3-changelog.md
@@ -5,7 +5,6 @@ date: 2019-04-09 10:11:54
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.3
 ---
 

--- a/content/en/changelogs/1.13.4-changelog.md
+++ b/content/en/changelogs/1.13.4-changelog.md
@@ -5,7 +5,6 @@ date: 2019-04-15 13:22:53
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.4
 ---
 

--- a/content/en/changelogs/1.13.5-changelog.md
+++ b/content/en/changelogs/1.13.5-changelog.md
@@ -5,7 +5,6 @@ date: 2019-04-22 10:32:39
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.5
 ---
 

--- a/content/en/changelogs/1.13.6-changelog.md
+++ b/content/en/changelogs/1.13.6-changelog.md
@@ -5,7 +5,6 @@ date: 2019-04-29 11:35:20
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.6
 ---
 

--- a/content/en/changelogs/1.13.7-changelog.md
+++ b/content/en/changelogs/1.13.7-changelog.md
@@ -5,7 +5,6 @@ date: 2019-05-16 13:49:24
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.7
 ---
 

--- a/content/en/changelogs/1.13.8-changelog.md
+++ b/content/en/changelogs/1.13.8-changelog.md
@@ -5,7 +5,6 @@ date: 2019-05-23 15:27:05
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.8
 ---
 

--- a/content/en/changelogs/1.13.9-changelog.md
+++ b/content/en/changelogs/1.13.9-changelog.md
@@ -5,7 +5,6 @@ date: 2019-06-10 14:50:42
 tags:
   - changelogs
   - 1.13
-  - deprecated
 version: 1.13.9
 ---
 

--- a/content/en/changelogs/1.14.0-changelog.md
+++ b/content/en/changelogs/1.14.0-changelog.md
@@ -5,7 +5,6 @@ date: 2019-05-20 15:28:53
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.0
 ---
 

--- a/content/en/changelogs/1.14.1-changelog.md
+++ b/content/en/changelogs/1.14.1-changelog.md
@@ -5,7 +5,6 @@ date: 2019-05-24 11:17:23
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.1
 ---
 

--- a/content/en/changelogs/1.14.10-changelog.md
+++ b/content/en/changelogs/1.14.10-changelog.md
@@ -5,7 +5,6 @@ date: 2019-07-18 12:07:45
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.10
 ---
 

--- a/content/en/changelogs/1.14.11-changelog.md
+++ b/content/en/changelogs/1.14.11-changelog.md
@@ -5,7 +5,6 @@ date: 2019-07-23 17:50:37
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.11
 ---
 

--- a/content/en/changelogs/1.14.12-changelog.md
+++ b/content/en/changelogs/1.14.12-changelog.md
@@ -5,7 +5,6 @@ date: 2019-07-29 13:41:43
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.12
 ---
 

--- a/content/en/changelogs/1.14.13-changelog.md
+++ b/content/en/changelogs/1.14.13-changelog.md
@@ -5,7 +5,6 @@ date: 2019-08-05 10:39:41
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.13
 ---
 

--- a/content/en/changelogs/1.14.14-changelog.md
+++ b/content/en/changelogs/1.14.14-changelog.md
@@ -5,7 +5,6 @@ date: 2019-08-14 09:38:01
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.14
 ---
 

--- a/content/en/changelogs/1.14.15-changelog.md
+++ b/content/en/changelogs/1.14.15-changelog.md
@@ -5,7 +5,6 @@ date: 2019-09-16 14:09:59
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.15
 ---
 

--- a/content/en/changelogs/1.14.2-changelog.md
+++ b/content/en/changelogs/1.14.2-changelog.md
@@ -5,7 +5,6 @@ date: 2019-05-28 14:57:44
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.2
 ---
 

--- a/content/en/changelogs/1.14.3-changelog.md
+++ b/content/en/changelogs/1.14.3-changelog.md
@@ -5,7 +5,6 @@ date: 2019-06-04 11:15:15
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.3
 ---
 

--- a/content/en/changelogs/1.14.4-changelog.md
+++ b/content/en/changelogs/1.14.4-changelog.md
@@ -5,7 +5,6 @@ date: 2019-06-10 12:35:56
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.4
 ---
 

--- a/content/en/changelogs/1.14.5-changelog.md
+++ b/content/en/changelogs/1.14.5-changelog.md
@@ -5,7 +5,6 @@ date: 2019-06-12 10:23:28
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.5
 ---
 

--- a/content/en/changelogs/1.14.6-changelog.md
+++ b/content/en/changelogs/1.14.6-changelog.md
@@ -5,7 +5,6 @@ date: 2019-06-17 12:46:02
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.6
 ---
 

--- a/content/en/changelogs/1.14.7-changelog.md
+++ b/content/en/changelogs/1.14.7-changelog.md
@@ -5,7 +5,6 @@ date: 2019-06-24 10:03:33
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.7
 ---
 

--- a/content/en/changelogs/1.14.8-changelog.md
+++ b/content/en/changelogs/1.14.8-changelog.md
@@ -5,7 +5,6 @@ date: 2019-07-01 10:14:34
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.8
 ---
 

--- a/content/en/changelogs/1.14.9-changelog.md
+++ b/content/en/changelogs/1.14.9-changelog.md
@@ -5,7 +5,6 @@ date: 2019-07-08 17:11:13
 tags:
   - changelogs
   - 1.14
-  - deprecated
 version: 1.14.9
 ---
 

--- a/content/en/changelogs/1.15.0-changelog.md
+++ b/content/en/changelogs/1.15.0-changelog.md
@@ -5,7 +5,6 @@ date: 2019-07-19 13:28:47
 tags:
   - changelogs
   - 1.15
-  - deprecated
 version: 1.15.0
 ---
 

--- a/content/en/changelogs/1.15.1-changelog.md
+++ b/content/en/changelogs/1.15.1-changelog.md
@@ -5,7 +5,6 @@ date: 2019-07-29 13:04:12
 tags:
   - changelogs
   - 1.15
-  - deprecated
 version: 1.15.1
 ---
 

--- a/content/en/changelogs/1.15.2-changelog.md
+++ b/content/en/changelogs/1.15.2-changelog.md
@@ -5,7 +5,6 @@ date: 2019-08-12 16:49:02
 tags:
   - changelogs
   - 1.15
-  - deprecated
 version: 1.15.2
 ---
 

--- a/content/en/changelogs/1.15.3-changelog.md
+++ b/content/en/changelogs/1.15.3-changelog.md
@@ -5,7 +5,6 @@ date: 2019-08-26 17:09:31
 tags:
   - changelogs
   - 1.15
-  - deprecated
 version: 1.15.3
 ---
 

--- a/content/en/changelogs/1.15.4-changelog.md
+++ b/content/en/changelogs/1.15.4-changelog.md
@@ -5,7 +5,6 @@ date: 2019-09-17 13:36:04
 tags:
   - changelogs
   - 1.15
-  - deprecated
 version: 1.15.4
 ---
 

--- a/content/en/changelogs/1.15.5-changelog.md
+++ b/content/en/changelogs/1.15.5-changelog.md
@@ -5,7 +5,6 @@ date: 2019-10-01 17:12:01
 tags:
   - changelogs
   - 1.15
-  - deprecated
 version: 1.15.5
 ---
 

--- a/content/en/changelogs/1.15.6-changelog.md
+++ b/content/en/changelogs/1.15.6-changelog.md
@@ -5,7 +5,6 @@ date: 2019-10-23 16:58:57
 tags:
   - changelogs
   - 1.15
-  - deprecated
 version: 1.15.6
 ---
 

--- a/content/en/changelogs/1.15.7-changelog.md
+++ b/content/en/changelogs/1.15.7-changelog.md
@@ -5,7 +5,6 @@ date: 2019-12-03 11:41:43
 tags:
   - changelogs
   - 1.15
-  - deprecated
 version: 1.15.7
 ---
 

--- a/content/en/changelogs/1.16.0-changelog.md
+++ b/content/en/changelogs/1.16.0-changelog.md
@@ -5,7 +5,6 @@ date: 2019-09-09 10:52:30
 tags:
   - changelogs
   - 1.16
-  - deprecated
 version: 1.16.0
 ---
 

--- a/content/en/changelogs/1.16.1-changelog.md
+++ b/content/en/changelogs/1.16.1-changelog.md
@@ -5,7 +5,6 @@ date: 2019-09-17 13:48:16
 tags:
   - changelogs
   - 1.16
-  - deprecated
 version: 1.16.1
 ---
 

--- a/content/en/changelogs/1.16.2-changelog.md
+++ b/content/en/changelogs/1.16.2-changelog.md
@@ -5,7 +5,6 @@ date: 2019-10-01 17:08:45
 tags:
   - changelogs
   - 1.16
-  - deprecated
 version: 1.16.2
 ---
 

--- a/content/en/changelogs/1.16.3-changelog.md
+++ b/content/en/changelogs/1.16.3-changelog.md
@@ -5,7 +5,6 @@ date: 2019-10-14 15:07:32
 tags:
   - changelogs
   - 1.16
-  - deprecated
 version: 1.16.3
 ---
 

--- a/content/en/changelogs/1.16.4-changelog.md
+++ b/content/en/changelogs/1.16.4-changelog.md
@@ -5,7 +5,6 @@ date: 2019-10-23 16:53:30
 tags:
   - changelogs
   - 1.16
-  - deprecated
 version: 1.16.4
 ---
 

--- a/content/en/changelogs/1.16.5-changelog.md
+++ b/content/en/changelogs/1.16.5-changelog.md
@@ -5,7 +5,6 @@ date: 2019-11-11 13:59:16
 tags:
   - changelogs
   - 1.16
-  - deprecated
 version: 1.16.5
 ---
 

--- a/content/en/changelogs/1.16.6-changelog.md
+++ b/content/en/changelogs/1.16.6-changelog.md
@@ -5,7 +5,6 @@ date: 2019-12-03 10:37:55
 tags:
   - changelogs
   - 1.16
-  - deprecated
 version: 1.16.6
 ---
 

--- a/content/en/changelogs/1.16.7-changelog.md
+++ b/content/en/changelogs/1.16.7-changelog.md
@@ -5,7 +5,6 @@ date: 2020-03-09 19:34:42 +0000
 tags:
   - changelogs
   - 1.16
-  - deprecated
 version: 1.16.7
 ---
 

--- a/content/en/changelogs/1.17.0-changelog.md
+++ b/content/en/changelogs/1.17.0-changelog.md
@@ -5,7 +5,6 @@ date: 2019-11-04 14:07:43
 tags:
   - changelogs
   - 1.17
-  - deprecated
 version: 1.17.0
 ---
 

--- a/content/en/changelogs/1.17.1-changelog.md
+++ b/content/en/changelogs/1.17.1-changelog.md
@@ -5,7 +5,6 @@ date: 2019-11-11 12:45:00
 tags:
   - changelogs
   - 1.17
-  - deprecated
 version: 1.17.1
 ---
 

--- a/content/en/changelogs/1.17.10-changelog.md
+++ b/content/en/changelogs/1.17.10-changelog.md
@@ -5,7 +5,6 @@ date: 2020-04-03 18:52:34 +0000
 tags:
   - changelogs
   - 1.17
-  - deprecated
 version: 1.17.10
 ---
 

--- a/content/en/changelogs/1.17.2-changelog.md
+++ b/content/en/changelogs/1.17.2-changelog.md
@@ -5,7 +5,6 @@ date: 2019-11-20 11:15:31
 tags:
   - changelogs
   - 1.17
-  - deprecated
 version: 1.17.2
 ---
 

--- a/content/en/changelogs/1.17.3-changelog.md
+++ b/content/en/changelogs/1.17.3-changelog.md
@@ -5,7 +5,6 @@ date: 2019-12-03 08:51:01
 tags:
   - changelogs
   - 1.17
-  - deprecated
 version: 1.17.3
 ---
 

--- a/content/en/changelogs/1.17.4-changelog.md
+++ b/content/en/changelogs/1.17.4-changelog.md
@@ -5,7 +5,6 @@ date: 2019-12-12 15:31:46 +0000
 tags:
   - changelogs
   - 1.17
-  - deprecated
 version: 1.17.4
 ---
 

--- a/content/en/changelogs/1.17.5-changelog.md
+++ b/content/en/changelogs/1.17.5-changelog.md
@@ -5,7 +5,6 @@ date: 2019-12-16 21:21:31 +0000
 tags:
   - changelogs
   - 1.17
-  - deprecated
 version: 1.17.5
 ---
 

--- a/content/en/changelogs/1.17.6-changelog.md
+++ b/content/en/changelogs/1.17.6-changelog.md
@@ -5,7 +5,6 @@ date: 2020-01-14 14:19:54 +0000
 tags:
   - changelogs
   - 1.17
-  - deprecated
 version: 1.17.6
 ---
 

--- a/content/en/changelogs/1.17.7-changelog.md
+++ b/content/en/changelogs/1.17.7-changelog.md
@@ -5,7 +5,6 @@ date: 2020-03-09 19:37:53 +0000
 tags:
   - changelogs
   - 1.17
-  - deprecated
 version: 1.17.7
 ---
 

--- a/content/en/changelogs/1.17.8-changelog.md
+++ b/content/en/changelogs/1.17.8-changelog.md
@@ -5,7 +5,6 @@ date: 2020-03-20 20:17:31 +0000
 tags:
   - changelogs
   - 1.17
-  - deprecated
 version: 1.17.8
 ---
 

--- a/content/en/changelogs/1.17.9-changelog.md
+++ b/content/en/changelogs/1.17.9-changelog.md
@@ -5,7 +5,6 @@ date: 2020-03-30 20:54:12 +0000
 tags:
   - changelogs
   - 1.17
-  - deprecated
 version: 1.17.9
 ---
 

--- a/content/en/changelogs/1.18.0-changelog.md
+++ b/content/en/changelogs/1.18.0-changelog.md
@@ -5,7 +5,6 @@ date: 2020-01-22 13:18:57 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.0
 ---
 

--- a/content/en/changelogs/1.18.1-changelog.md
+++ b/content/en/changelogs/1.18.1-changelog.md
@@ -5,7 +5,6 @@ date: 2020-01-31 19:10:30 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.1
 ---
 

--- a/content/en/changelogs/1.18.10-changelog.md
+++ b/content/en/changelogs/1.18.10-changelog.md
@@ -5,7 +5,6 @@ date: 2020-05-05 13:46:33 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.10
 ---
 

--- a/content/en/changelogs/1.18.11-changelog.md
+++ b/content/en/changelogs/1.18.11-changelog.md
@@ -5,7 +5,6 @@ date: 2020-05-11 13:10:33 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.11
 ---
 

--- a/content/en/changelogs/1.18.12-changelog.md
+++ b/content/en/changelogs/1.18.12-changelog.md
@@ -5,7 +5,6 @@ date: 2020-05-26 13:00:37 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.12
 ---
 

--- a/content/en/changelogs/1.18.2-changelog.md
+++ b/content/en/changelogs/1.18.2-changelog.md
@@ -5,7 +5,6 @@ date: 2020-02-10 14:31:18 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.2
 ---
 

--- a/content/en/changelogs/1.18.3-changelog.md
+++ b/content/en/changelogs/1.18.3-changelog.md
@@ -5,7 +5,6 @@ date: 2020-02-20 18:36:42 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.3
 ---
 

--- a/content/en/changelogs/1.18.4-changelog.md
+++ b/content/en/changelogs/1.18.4-changelog.md
@@ -5,7 +5,6 @@ date: 2020-02-27 21:59:13 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.4
 ---
 

--- a/content/en/changelogs/1.18.5-changelog.md
+++ b/content/en/changelogs/1.18.5-changelog.md
@@ -5,7 +5,6 @@ date: 2020-03-09 19:44:10 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.5
 ---
 

--- a/content/en/changelogs/1.18.6-changelog.md
+++ b/content/en/changelogs/1.18.6-changelog.md
@@ -5,7 +5,6 @@ date: 2020-03-16 21:58:05 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.6
 ---
 

--- a/content/en/changelogs/1.18.7-changelog.md
+++ b/content/en/changelogs/1.18.7-changelog.md
@@ -5,7 +5,6 @@ date: 2020-03-30 22:44:12 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.7
 ---
 

--- a/content/en/changelogs/1.18.8-changelog.md
+++ b/content/en/changelogs/1.18.8-changelog.md
@@ -5,7 +5,6 @@ date: 2020-04-03 18:55:22 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.8
 ---
 

--- a/content/en/changelogs/1.18.9-changelog.md
+++ b/content/en/changelogs/1.18.9-changelog.md
@@ -5,7 +5,6 @@ date: 2020-04-15 18:01:42 +0000
 tags:
   - changelogs
   - 1.18
-  - deprecated
 version: 1.18.9
 ---
 

--- a/content/en/changelogs/1.19.0-changelog.md
+++ b/content/en/changelogs/1.19.0-changelog.md
@@ -5,7 +5,6 @@ date: 2020-03-11 20:23:08 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.0
 ---
 

--- a/content/en/changelogs/1.19.1-changelog.md
+++ b/content/en/changelogs/1.19.1-changelog.md
@@ -5,7 +5,6 @@ date: 2020-03-16 21:54:51 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.1
 ---
 

--- a/content/en/changelogs/1.19.10-changelog.md
+++ b/content/en/changelogs/1.19.10-changelog.md
@@ -5,7 +5,6 @@ date: 2020-05-26 13:04:08 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.10
 ---
 

--- a/content/en/changelogs/1.19.11-changelog.md
+++ b/content/en/changelogs/1.19.11-changelog.md
@@ -5,7 +5,6 @@ date: 2020-06-01 14:38:23 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.11
 ---
 

--- a/content/en/changelogs/1.19.12-changelog.md
+++ b/content/en/changelogs/1.19.12-changelog.md
@@ -5,7 +5,6 @@ date: 2020-06-30 20:38:40 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.12
 ---
 

--- a/content/en/changelogs/1.19.13-changelog.md
+++ b/content/en/changelogs/1.19.13-changelog.md
@@ -5,7 +5,6 @@ date: 2020-07-28 01:22:03 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.13
 ---
 

--- a/content/en/changelogs/1.19.14-changelog.md
+++ b/content/en/changelogs/1.19.14-changelog.md
@@ -5,7 +5,6 @@ date: 2020-08-13 23:44:46 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.14
 ---
 

--- a/content/en/changelogs/1.19.2-changelog.md
+++ b/content/en/changelogs/1.19.2-changelog.md
@@ -5,7 +5,6 @@ date: 2020-03-20 21:17:01 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.2
 ---
 

--- a/content/en/changelogs/1.19.3-changelog.md
+++ b/content/en/changelogs/1.19.3-changelog.md
@@ -5,7 +5,6 @@ date: 2020-03-30 23:00:57 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.3
 ---
 

--- a/content/en/changelogs/1.19.4-changelog.md
+++ b/content/en/changelogs/1.19.4-changelog.md
@@ -5,7 +5,6 @@ date: 2020-04-03 18:58:22 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.4
 ---
 

--- a/content/en/changelogs/1.19.5-changelog.md
+++ b/content/en/changelogs/1.19.5-changelog.md
@@ -5,7 +5,6 @@ date: 2020-04-15 18:04:36 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.5
 ---
 

--- a/content/en/changelogs/1.19.6-changelog.md
+++ b/content/en/changelogs/1.19.6-changelog.md
@@ -5,7 +5,6 @@ date: 2020-04-23 15:53:53 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.6
 ---
 

--- a/content/en/changelogs/1.19.7-changelog.md
+++ b/content/en/changelogs/1.19.7-changelog.md
@@ -5,7 +5,6 @@ date: 2020-05-05 11:53:08 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.7
 ---
 

--- a/content/en/changelogs/1.19.8-changelog.md
+++ b/content/en/changelogs/1.19.8-changelog.md
@@ -5,7 +5,6 @@ date: 2020-05-11 13:15:12 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.8
 ---
 

--- a/content/en/changelogs/1.19.9-changelog.md
+++ b/content/en/changelogs/1.19.9-changelog.md
@@ -5,7 +5,6 @@ date: 2020-05-19 13:43:05 +0000
 tags:
   - changelogs
   - 1.19
-  - deprecated
 version: 1.19.9
 ---
 

--- a/content/en/changelogs/1.2.1-changelog.md
+++ b/content/en/changelogs/1.2.1-changelog.md
@@ -5,7 +5,6 @@ date: 2017-08-09 20:09:52
 tags:
   - changelogs
   - 1.2
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/512f9f19181c4c19b5d614c44aa9bcaf.js"></script>

--- a/content/en/changelogs/1.2.2-changelog.md
+++ b/content/en/changelogs/1.2.2-changelog.md
@@ -5,7 +5,6 @@ date: 2017-08-22 11:55:01
 tags:
   - changelogs
   - 1.2
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/84b75e3701652dfedb86e20b806cbc39.js"></script>

--- a/content/en/changelogs/1.20.0-changelog.md
+++ b/content/en/changelogs/1.20.0-changelog.md
@@ -5,7 +5,6 @@ date: 2020-05-04 17:59:33 +0000
 tags:
   - changelogs
   - 1.20
-  - deprecated
 version: 1.20.0
 ---
 

--- a/content/en/changelogs/1.20.1-changelog.md
+++ b/content/en/changelogs/1.20.1-changelog.md
@@ -5,7 +5,6 @@ date: 2020-05-11 13:19:23 +0000
 tags:
   - changelogs
   - 1.20
-  - deprecated
 version: 1.20.1
 ---
 

--- a/content/en/changelogs/1.20.2-changelog.md
+++ b/content/en/changelogs/1.20.2-changelog.md
@@ -5,7 +5,6 @@ date: 2020-05-18 14:29:08 +0000
 tags:
   - changelogs
   - 1.20
-  - deprecated
 version: 1.20.2
 ---
 

--- a/content/en/changelogs/1.20.3-changelog.md
+++ b/content/en/changelogs/1.20.3-changelog.md
@@ -5,7 +5,6 @@ date: 2020-05-26 15:33:27 +0000
 tags:
   - changelogs
   - 1.20
-  - deprecated
 version: 1.20.3
 ---
 

--- a/content/en/changelogs/1.20.4-changelog.md
+++ b/content/en/changelogs/1.20.4-changelog.md
@@ -5,7 +5,6 @@ date: 2020-06-01 16:56:02 +0000
 tags:
   - changelogs
   - 1.20
-  - deprecated
 version: 1.20.4
 ---
 

--- a/content/en/changelogs/1.20.5-changelog.md
+++ b/content/en/changelogs/1.20.5-changelog.md
@@ -5,7 +5,6 @@ date: 2020-06-08 15:10:44 +0000
 tags:
   - changelogs
   - 1.20
-  - deprecated
 version: 1.20.5
 ---
 

--- a/content/en/changelogs/1.20.6-changelog.md
+++ b/content/en/changelogs/1.20.6-changelog.md
@@ -5,7 +5,6 @@ date: 2020-06-25 17:12:29 +0000
 tags:
   - changelogs
   - 1.20
-  - deprecated
 version: 1.20.6
 ---
 

--- a/content/en/changelogs/1.20.7-changelog.md
+++ b/content/en/changelogs/1.20.7-changelog.md
@@ -5,7 +5,6 @@ date: 2020-07-22 22:22:44 +0000
 tags:
   - changelogs
   - 1.20
-  - deprecated
 version: 1.20.7
 ---
 

--- a/content/en/changelogs/1.20.8-changelog.md
+++ b/content/en/changelogs/1.20.8-changelog.md
@@ -5,7 +5,6 @@ date: 2020-08-13 00:20:30 +0000
 tags:
   - changelogs
   - 1.20
-  - deprecated
 version: 1.20.8
 ---
 

--- a/content/en/changelogs/1.21.0-changelog.md
+++ b/content/en/changelogs/1.21.0-changelog.md
@@ -5,7 +5,6 @@ date: 2020-06-29 18:46:10 +0000
 tags:
   - changelogs
   - 1.21
-  - deprecated
 version: 1.21.0
 ---
 

--- a/content/en/changelogs/1.21.1-changelog.md
+++ b/content/en/changelogs/1.21.1-changelog.md
@@ -5,7 +5,6 @@ date: 2020-07-22 17:46:16 +0000
 tags:
   - changelogs
   - 1.21
-  - deprecated
 version: 1.21.1
 ---
 

--- a/content/en/changelogs/1.21.2-changelog.md
+++ b/content/en/changelogs/1.21.2-changelog.md
@@ -5,7 +5,6 @@ date: 2020-07-24 02:06:47 +0000
 tags:
   - changelogs
   - 1.21
-  - deprecated
 version: 1.21.2
 ---
 

--- a/content/en/changelogs/1.21.3-changelog.md
+++ b/content/en/changelogs/1.21.3-changelog.md
@@ -5,7 +5,6 @@ date: 2020-08-08 00:08:18 +0000
 tags:
   - changelogs
   - 1.21
-  - deprecated
 version: 1.21.3
 ---
 

--- a/content/en/changelogs/1.21.4-changelog.md
+++ b/content/en/changelogs/1.21.4-changelog.md
@@ -5,7 +5,6 @@ date: 2020-08-13 00:23:38 +0000
 tags:
   - changelogs
   - 1.21
-  - deprecated
 version: 1.21.4
 ---
 

--- a/content/en/changelogs/1.21.5-changelog.md
+++ b/content/en/changelogs/1.21.5-changelog.md
@@ -5,7 +5,6 @@ date: 2020-12-07 23:09:05 +0000
 tags:
   - changelogs
   - 1.21
-  - deprecated
 version: 1.21.5
 ---
 

--- a/content/en/changelogs/1.22.0-changelog.md
+++ b/content/en/changelogs/1.22.0-changelog.md
@@ -5,7 +5,6 @@ date: 2020-08-24 16:10:02 +0000
 tags:
   - changelogs
   - 1.22
-  - deprecated
 version: 1.22.0
 ---
 

--- a/content/en/changelogs/1.22.1-changelog.md
+++ b/content/en/changelogs/1.22.1-changelog.md
@@ -5,7 +5,6 @@ date: 2020-08-31 14:48:37 +0000
 tags:
   - changelogs
   - 1.22
-  - deprecated
 version: 1.22.1
 ---
 

--- a/content/en/changelogs/1.22.2-changelog.md
+++ b/content/en/changelogs/1.22.2-changelog.md
@@ -5,7 +5,6 @@ date: 2020-10-13 15:18:00 +0000
 tags:
   - changelogs
   - 1.22
-  - deprecated
 version: 1.22.2
 ---
 

--- a/content/en/changelogs/1.22.3-changelog.md
+++ b/content/en/changelogs/1.22.3-changelog.md
@@ -5,7 +5,6 @@ date: 2020-12-01 17:26:40 +0000
 tags:
   - changelogs
   - 1.22
-  - deprecated
 version: 1.22.3
 ---
 

--- a/content/en/changelogs/1.22.4-changelog.md
+++ b/content/en/changelogs/1.22.4-changelog.md
@@ -5,7 +5,6 @@ date: 2020-12-08 14:56:16 +0000
 tags:
   - changelogs
   - 1.22
-  - deprecated
 version: 1.22.4
 ---
 

--- a/content/en/changelogs/1.22.5-changelog.md
+++ b/content/en/changelogs/1.22.5-changelog.md
@@ -5,7 +5,6 @@ date: 2021-01-26 23:06:26 +0000
 tags:
   - changelogs
   - 1.22
-  - deprecated
 version: 1.22.5
 type: changelog
 ---

--- a/content/en/changelogs/1.22.6-changelog.md
+++ b/content/en/changelogs/1.22.6-changelog.md
@@ -5,7 +5,6 @@ date: 2021-01-28 02:11:57 +0000
 tags:
   - changelogs
   - 1.22
-  - deprecated
 version: 1.22.6
 ---
 

--- a/content/en/changelogs/1.23.0-changelog.md
+++ b/content/en/changelogs/1.23.0-changelog.md
@@ -5,7 +5,6 @@ date: 2020-10-20 16:38:34 +0000
 tags:
   - changelogs
   - 1.23
-  - deprecated
 version: 1.23.0
 ---
 

--- a/content/en/changelogs/1.23.1-changelog.md
+++ b/content/en/changelogs/1.23.1-changelog.md
@@ -5,7 +5,6 @@ date: 2020-11-03 14:34:07 +0000
 tags:
   - changelogs
   - 1.23
-  - deprecated
 version: 1.23.1
 ---
 

--- a/content/en/changelogs/1.23.2-changelog.md
+++ b/content/en/changelogs/1.23.2-changelog.md
@@ -5,7 +5,6 @@ date: 2020-11-16 17:26:41 +0000
 tags:
   - changelogs
   - 1.23
-  - deprecated
 version: 1.23.2
 ---
 

--- a/content/en/changelogs/1.23.3-changelog.md
+++ b/content/en/changelogs/1.23.3-changelog.md
@@ -5,7 +5,6 @@ date: 2020-12-01 18:37:53 +0000
 tags:
   - changelogs
   - 1.23
-  - deprecated
 version: 1.23.3
 ---
 

--- a/content/en/changelogs/1.23.4-changelog.md
+++ b/content/en/changelogs/1.23.4-changelog.md
@@ -5,7 +5,6 @@ date: 2020-12-08 16:31:32 +0000
 tags:
   - changelogs
   - 1.23
-  - deprecated
 version: 1.23.4
 ---
 

--- a/content/en/changelogs/1.23.5-changelog.md
+++ b/content/en/changelogs/1.23.5-changelog.md
@@ -5,7 +5,6 @@ date: 2020-12-14 19:08:41 +0000
 tags:
   - changelogs
   - 1.23
-  - deprecated
 version: 1.23.5
 ---
 

--- a/content/en/changelogs/1.23.6-changelog.md
+++ b/content/en/changelogs/1.23.6-changelog.md
@@ -5,7 +5,6 @@ date: 2021-01-28 14:39:41 +0000
 tags:
   - changelogs
   - 1.23
-  - deprecated
 version: 1.23.6
 ---
 

--- a/content/en/changelogs/1.23.7-changelog.md
+++ b/content/en/changelogs/1.23.7-changelog.md
@@ -5,7 +5,6 @@ date: 2021-02-19 01:25:30 +0000
 tags:
   - changelogs
   - 1.23
-  - deprecated
 version: 1.23.7
 ---
 

--- a/content/en/changelogs/1.24.0-changelog.md
+++ b/content/en/changelogs/1.24.0-changelog.md
@@ -5,7 +5,6 @@ date: 2020-12-14 20:34:17 +0000
 tags:
   - changelogs
   - 1.24
-  - deprecated
 version: 1.24.0
 ---
 

--- a/content/en/changelogs/1.24.1-changelog.md
+++ b/content/en/changelogs/1.24.1-changelog.md
@@ -5,7 +5,6 @@ date: 2020-12-21 23:36:25 +0000
 tags:
   - changelogs
   - 1.24
-  - deprecated
 version: 1.24.1
 ---
 

--- a/content/en/changelogs/1.24.2-changelog.md
+++ b/content/en/changelogs/1.24.2-changelog.md
@@ -5,7 +5,6 @@ date: 2021-01-06 18:32:52 +0000
 tags:
   - changelogs
   - 1.24
-  - deprecated
 version: 1.24.2
 ---
 

--- a/content/en/changelogs/1.24.3-changelog.md
+++ b/content/en/changelogs/1.24.3-changelog.md
@@ -5,7 +5,6 @@ date: 2021-01-27 15:40:26 +0000
 tags:
   - changelogs
   - 1.24
-  - deprecated
 version: 1.24.3
 ---
 

--- a/content/en/changelogs/1.24.4-changelog.md
+++ b/content/en/changelogs/1.24.4-changelog.md
@@ -5,7 +5,6 @@ date: 2021-02-03 23:13:08 +0000
 tags:
   - changelogs
   - 1.24
-  - deprecated
 version: 1.24.4
 ---
 

--- a/content/en/changelogs/1.24.5-changelog.md
+++ b/content/en/changelogs/1.24.5-changelog.md
@@ -5,7 +5,6 @@ date: 2021-05-27 08:56:51 +0000
 tags:
   - changelogs
   - 1.24
-  - deprecated
 version: 1.24.5
 ---
 

--- a/content/en/changelogs/1.24.6-changelog.md
+++ b/content/en/changelogs/1.24.6-changelog.md
@@ -5,7 +5,6 @@ date: 2021-07-01 20:40:34 +0000
 tags:
   - changelogs
   - 1.24
-  - deprecated
 version: 1.24.6
 ---
 

--- a/content/en/changelogs/1.25.0-changelog.md
+++ b/content/en/changelogs/1.25.0-changelog.md
@@ -5,7 +5,6 @@ date: 2021-02-23 22:05:06 +0000
 tags:
   - changelogs
   - 1.25
-  - deprecated
 version: 1.25.0
 ---
 

--- a/content/en/changelogs/1.25.1-changelog.md
+++ b/content/en/changelogs/1.25.1-changelog.md
@@ -5,7 +5,6 @@ date: 2021-03-03 08:29:00 +0000
 tags:
   - changelogs
   - 1.25
-  - deprecated
 version: 1.25.1
 ---
 

--- a/content/en/changelogs/1.25.2-changelog.md
+++ b/content/en/changelogs/1.25.2-changelog.md
@@ -5,7 +5,6 @@ date: 2021-03-09 07:57:50 +0000
 tags:
   - changelogs
   - 1.25
-  - deprecated
 version: 1.25.2
 ---
 

--- a/content/en/changelogs/1.25.3-changelog.md
+++ b/content/en/changelogs/1.25.3-changelog.md
@@ -5,7 +5,6 @@ date: 2021-03-22 20:40:39 +0000
 tags:
   - changelogs
   - 1.25
-  - deprecated
 version: 1.25.3
 ---
 

--- a/content/en/changelogs/1.25.4-changelog.md
+++ b/content/en/changelogs/1.25.4-changelog.md
@@ -5,7 +5,6 @@ date: 2021-04-01 02:38:40 +0000
 tags:
   - changelogs
   - 1.25
-  - deprecated
 version: 1.25.4
 ---
 

--- a/content/en/changelogs/1.25.5-changelog.md
+++ b/content/en/changelogs/1.25.5-changelog.md
@@ -5,7 +5,6 @@ date: 2021-05-27 09:04:10 +0000
 tags:
   - changelogs
   - 1.25
-  - deprecated
 version: 1.25.5
 ---
 

--- a/content/en/changelogs/1.25.6-changelog.md
+++ b/content/en/changelogs/1.25.6-changelog.md
@@ -5,7 +5,6 @@ date: 2021-06-18 20:22:00 +0000
 tags:
   - changelogs
   - 1.25
-  - deprecated
 version: 1.25.6
 ---
 

--- a/content/en/changelogs/1.25.7-changelog.md
+++ b/content/en/changelogs/1.25.7-changelog.md
@@ -5,7 +5,6 @@ date: 2021-06-26 08:01:26 +0000
 tags:
   - changelogs
   - 1.25
-  - deprecated
 version: 1.25.7
 ---
 

--- a/content/en/changelogs/1.26.0-changelog.md
+++ b/content/en/changelogs/1.26.0-changelog.md
@@ -5,7 +5,6 @@ date: 2021-04-23 22:04:51 +0000
 tags:
   - changelogs
   - 1.26
-  - deprecated
 version: 1.26.0
 ---
 

--- a/content/en/changelogs/1.26.1-changelog.md
+++ b/content/en/changelogs/1.26.1-changelog.md
@@ -5,7 +5,6 @@ date: 2021-04-29 18:34:42 +0000
 tags:
   - changelogs
   - 1.26
-  - deprecated
 version: 1.26.1
 ---
 

--- a/content/en/changelogs/1.26.2-changelog.md
+++ b/content/en/changelogs/1.26.2-changelog.md
@@ -5,7 +5,6 @@ date: 2021-05-03 23:49:27 +0000
 tags:
   - changelogs
   - 1.26
-  - deprecated
 version: 1.26.2
 ---
 

--- a/content/en/changelogs/1.26.3-changelog.md
+++ b/content/en/changelogs/1.26.3-changelog.md
@@ -5,7 +5,6 @@ date: 2021-05-13 19:16:04 +0000
 tags:
   - changelogs
   - 1.26
-  - deprecated
 version: 1.26.3
 ---
 

--- a/content/en/changelogs/1.26.4-changelog.md
+++ b/content/en/changelogs/1.26.4-changelog.md
@@ -5,7 +5,6 @@ date: 2021-06-18 20:39:56 +0000
 tags:
   - changelogs
   - 1.26
-  - deprecated
 version: 1.26.4
 ---
 

--- a/content/en/changelogs/1.26.5-changelog.md
+++ b/content/en/changelogs/1.26.5-changelog.md
@@ -5,7 +5,6 @@ date: 2021-07-01 00:49:04 +0000
 tags:
   - changelogs
   - 1.26
-  - deprecated
 version: 1.26.5
 ---
 

--- a/content/en/changelogs/1.26.6-changelog.md
+++ b/content/en/changelogs/1.26.6-changelog.md
@@ -5,7 +5,6 @@ date: 2021-07-01 00:49:04 +0000
 tags:
   - changelogs
   - 1.26
-  - deprecated
 version: 1.26.6
 ---
 

--- a/content/en/changelogs/1.3.0-changelog.md
+++ b/content/en/changelogs/1.3.0-changelog.md
@@ -5,7 +5,6 @@ date: 2017-09-07 21:28:06
 tags:
   - changelogs
   - 1.3
-  - deprecated
 ---
 
 **Version 1.3.0 requires Halyard v0.34.0+**

--- a/content/en/changelogs/1.3.1-changelog.md
+++ b/content/en/changelogs/1.3.1-changelog.md
@@ -5,7 +5,6 @@ date: 2017-09-18 16:48:39
 tags:
   - changelogs
   - 1.3
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/021ff67e0ef7a4e1b271e0ea4344b3b4.js"></script>

--- a/content/en/changelogs/1.4.0-changelog.md
+++ b/content/en/changelogs/1.4.0-changelog.md
@@ -5,7 +5,6 @@ date: 2017-09-21 20:00:11
 tags:
   - changelogs
   - 1.4
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/52f2f6660077125e05808583c5bf63ee.js"></script>

--- a/content/en/changelogs/1.4.1-changelog.md
+++ b/content/en/changelogs/1.4.1-changelog.md
@@ -5,7 +5,6 @@ date: 2017-09-22 18:13:32
 tags:
   - changelogs
   - 1.4
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/87ffcdd472d315d75877312de01bb05d.js"></script>

--- a/content/en/changelogs/1.4.2-changelog.md
+++ b/content/en/changelogs/1.4.2-changelog.md
@@ -5,7 +5,6 @@ date: 2017-10-03 17:27:27
 tags:
   - changelogs
   - 1.4
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/c791562094c040e936776b501b42c7a6.js"></script>

--- a/content/en/changelogs/1.5.0-changelog.md
+++ b/content/en/changelogs/1.5.0-changelog.md
@@ -5,7 +5,6 @@ date: 2017-11-08 18:50:36
 tags:
   - changelogs
   - 1.5
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/d3d2ca93ebcc0fce546323723dee65ea.js"></script>

--- a/content/en/changelogs/1.5.1-changelog.md
+++ b/content/en/changelogs/1.5.1-changelog.md
@@ -5,7 +5,6 @@ date: 2017-11-30 21:48:29
 tags:
   - changelogs
   - 1.5
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/e884c78db5dead1a72c3f6b52c05738b.js"></script>

--- a/content/en/changelogs/1.5.2-changelog.md
+++ b/content/en/changelogs/1.5.2-changelog.md
@@ -5,7 +5,6 @@ date: 2017-12-22 17:30:58
 tags:
   - changelogs
   - 1.5
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/a2c02795c6239cc04118fa62de46d2ef.js"></script>

--- a/content/en/changelogs/1.5.3-changelog.md
+++ b/content/en/changelogs/1.5.3-changelog.md
@@ -5,7 +5,6 @@ date: 2018-01-09 20:55:22
 tags:
   - changelogs
   - 1.5
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/cdcbfd25eaa81464a4932cbb1f7c70e8.js"></script>

--- a/content/en/changelogs/1.5.4-changelog.md
+++ b/content/en/changelogs/1.5.4-changelog.md
@@ -5,7 +5,6 @@ date: 2018-01-10 18:45:23
 tags:
   - changelogs
   - 1.5
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/6b9fd632caeaefd32246074998af8498.js"></script>

--- a/content/en/changelogs/1.6.0-changelog.md
+++ b/content/en/changelogs/1.6.0-changelog.md
@@ -5,7 +5,6 @@ date: 2018-02-21 22:23:08
 tags:
   - changelogs
   - 1.6
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/235774d2d17f3bd96d3ed6c446b065a4.js"></script>

--- a/content/en/changelogs/1.6.1-changelog.md
+++ b/content/en/changelogs/1.6.1-changelog.md
@@ -5,7 +5,6 @@ date: 2018-04-04 15:21:03
 tags:
   - changelogs
   - 1.6
-  - deprecated
 ---
 
 # Spinnaker 1.6.1

--- a/content/en/changelogs/1.6.2-changelog.md
+++ b/content/en/changelogs/1.6.2-changelog.md
@@ -5,7 +5,6 @@ date: 2018-07-26 17:55:39
 tags:
   - changelogs
   - 1.6
-  - deprecated
 ---
 
 # Spinnaker 1.6.2

--- a/content/en/changelogs/1.7.0-changelog.md
+++ b/content/en/changelogs/1.7.0-changelog.md
@@ -5,7 +5,6 @@ date: 2018-04-25 12:06:36
 tags:
   - changelogs
   - 1.7
-  - deprecated
 ---
 
 # Spinnaker 1.7.0

--- a/content/en/changelogs/1.7.1-changelog.md
+++ b/content/en/changelogs/1.7.1-changelog.md
@@ -5,7 +5,6 @@ date: 2018-04-30 13:27:47
 tags:
   - changelogs
   - 1.7
-  - deprecated
 ---
 
 # Spinnaker 1.7.1

--- a/content/en/changelogs/1.7.2-changelog.md
+++ b/content/en/changelogs/1.7.2-changelog.md
@@ -5,7 +5,6 @@ date: 2018-05-01 11:22:26
 tags:
   - changelogs
   - 1.7
-  - deprecated
 ---
 
 # Spinnaker 1.7.2

--- a/content/en/changelogs/1.7.3-changelog.md
+++ b/content/en/changelogs/1.7.3-changelog.md
@@ -5,7 +5,6 @@ date: 2018-05-07 13:26:10
 tags:
   - changelogs
   - 1.7
-  - deprecated
 ---
 
 # Spinnaker 1.7.3

--- a/content/en/changelogs/1.7.4-changelog.md
+++ b/content/en/changelogs/1.7.4-changelog.md
@@ -5,7 +5,6 @@ date: 2018-05-14 13:03:48
 tags:
   - changelogs
   - 1.7
-  - deprecated
 ---
 
 # Spinnaker 1.7.4

--- a/content/en/changelogs/1.7.5-changelog.md
+++ b/content/en/changelogs/1.7.5-changelog.md
@@ -5,7 +5,6 @@ date: 2018-05-21 11:14:10
 tags:
   - changelogs
   - 1.7
-  - deprecated
 ---
 
 # Spinnaker 1.7.5

--- a/content/en/changelogs/1.7.6-changelog.md
+++ b/content/en/changelogs/1.7.6-changelog.md
@@ -5,7 +5,6 @@ date: 2018-05-29 12:26:28
 tags:
   - changelogs
   - 1.7
-  - deprecated
 ---
 
 # Spinnaker 1.7.6

--- a/content/en/changelogs/1.7.7-changelog.md
+++ b/content/en/changelogs/1.7.7-changelog.md
@@ -5,7 +5,6 @@ date: 2018-07-26 17:28:13
 tags:
   - changelogs
   - 1.7
-  - deprecated
 ---
 
 # Spinnaker 1.7.7

--- a/content/en/changelogs/1.7.8-changelog.md
+++ b/content/en/changelogs/1.7.8-changelog.md
@@ -5,7 +5,6 @@ date: 2018-08-29 15:10:06
 tags:
   - changelogs
   - 1.7
-  - deprecated
 version: 1.7.8
 ---
 

--- a/content/en/changelogs/1.8.0-changelog.md
+++ b/content/en/changelogs/1.8.0-changelog.md
@@ -5,7 +5,6 @@ date: 2018-06-22 13:48:39
 tags:
   - changelogs
   - 1.8
-  - deprecated
 ---
 
 # Spinnaker 1.8.0

--- a/content/en/changelogs/1.8.1-changelog.md
+++ b/content/en/changelogs/1.8.1-changelog.md
@@ -5,7 +5,6 @@ date: 2018-07-09 16:37:22
 tags:
   - changelogs
   - 1.8
-  - deprecated
 ---
 
 # Spinnaker 1.8.1

--- a/content/en/changelogs/1.8.2-changelog.md
+++ b/content/en/changelogs/1.8.2-changelog.md
@@ -5,7 +5,6 @@ date: 2018-07-23 10:54:30
 tags:
   - changelogs
   - 1.8
-  - deprecated
 ---
 
 # Spinnaker 1.8.2

--- a/content/en/changelogs/1.8.3-changelog.md
+++ b/content/en/changelogs/1.8.3-changelog.md
@@ -5,7 +5,6 @@ date: 2018-07-24 15:36:16
 tags:
   - changelogs
   - 1.8
-  - deprecated
 ---
 
 # Spinnaker 1.8.3

--- a/content/en/changelogs/1.8.4-changelog.md
+++ b/content/en/changelogs/1.8.4-changelog.md
@@ -5,7 +5,6 @@ date: 2018-07-26 16:26:58
 tags:
   - changelogs
   - 1.8
-  - deprecated
 ---
 
 # Spinnaker 1.8.4

--- a/content/en/changelogs/1.8.5-changelog.md
+++ b/content/en/changelogs/1.8.5-changelog.md
@@ -5,7 +5,6 @@ date: 2018-08-02 16:40:59
 tags:
   - changelogs
   - 1.8
-  - deprecated
 version: 1.8.5
 ---
 

--- a/content/en/changelogs/1.8.6-changelog.md
+++ b/content/en/changelogs/1.8.6-changelog.md
@@ -5,7 +5,6 @@ date: 2018-08-29 15:11:41
 tags:
   - changelogs
   - 1.8
-  - deprecated
 version: 1.8.6
 ---
 

--- a/content/en/changelogs/1.8.7-changelog.md
+++ b/content/en/changelogs/1.8.7-changelog.md
@@ -5,7 +5,6 @@ date: 2018-09-28 13:58:59
 tags:
   - changelogs
   - 1.8
-  - deprecated
 version: 1.8.7
 ---
 

--- a/content/en/changelogs/1.9.0-changelog.md
+++ b/content/en/changelogs/1.9.0-changelog.md
@@ -5,7 +5,6 @@ date: 2018-08-15 15:49:49
 tags:
   - changelogs
   - 1.9
-  - deprecated
 ---
 
 <script src="https://gist.github.com/spinnaker-release/942a9ed21d2555ae15b82a036a140e3a.js"/>

--- a/content/en/changelogs/1.9.1-changelog.md
+++ b/content/en/changelogs/1.9.1-changelog.md
@@ -5,7 +5,6 @@ date: 2018-08-28 10:13:57
 tags:
   - changelogs
   - 1.9
-  - deprecated
 version: 1.9.1
 ---
 

--- a/content/en/changelogs/1.9.2-changelog.md
+++ b/content/en/changelogs/1.9.2-changelog.md
@@ -5,7 +5,6 @@ date: 2018-08-29 16:08:26
 tags:
   - changelogs
   - 1.9
-  - deprecated
 version: 1.9.2
 ---
 

--- a/content/en/changelogs/1.9.3-changelog.md
+++ b/content/en/changelogs/1.9.3-changelog.md
@@ -5,7 +5,6 @@ date: 2018-09-10 12:14:09
 tags:
   - changelogs
   - 1.9
-  - deprecated
 version: 1.9.3
 ---
 

--- a/content/en/changelogs/1.9.4-changelog.md
+++ b/content/en/changelogs/1.9.4-changelog.md
@@ -5,7 +5,6 @@ date: 2018-09-26 11:33:02
 tags:
   - changelogs
   - 1.9
-  - deprecated
 version: 1.9.4
 ---
 

--- a/content/en/changelogs/1.9.5-changelog.md
+++ b/content/en/changelogs/1.9.5-changelog.md
@@ -5,7 +5,6 @@ date: 2018-10-01 13:15:45
 tags:
   - changelogs
   - 1.9
-  - deprecated
 version: 1.9.5
 ---
 

--- a/content/en/docs/releases/versions.md
+++ b/content/en/docs/releases/versions.md
@@ -7,10 +7,13 @@ menu:
 ---
 
 The Spinnaker releases listed below are top-level versions tying together each
-Spinnaker subcomponents' versions. These have been validated together in an
-end-to-end integration test suite curated by the Spinnaker community, and
-represent a more maintainable, easy to upgrade Spinnaker. While
-it's still possible to install each Spinnaker subcomponent's versions
+Spinnaker subcomponents' versions.
+
+These have been validated together in an end-to-end integration test suite
+curated by the Spinnaker community, and represent a more maintainable, easy to
+upgrade Spinnaker.
+
+While it's still possible to install each Spinnaker subcomponent's versions
 independently, there is no guarantee that they will work together.
 
 If you want to see what each top-level version is comprised of, run
@@ -19,8 +22,9 @@ If you want to see what each top-level version is comprised of, run
 hal version bom <version>
 ```
 
-to see the commit hash and tag matching `version-<version>` of each
-subcomponent.
+to see the commit hash and tag matching `v-<version>` of each
+subcomponent. Prior to Spinnaker Release `1.27.0` the tag pattern was
+`version-<version>`.
 
 ## Latest stable
 

--- a/layouts/shortcodes/deprecated-versions.html
+++ b/layouts/shortcodes/deprecated-versions.html
@@ -1,10 +1,43 @@
-{{ $changelogs := where $.Site.Pages "Section" "changelogs" }} 
-{{ range $changelogs.ByDate.Reverse }} {{ if (in .Params.tags "deprecated" )}}
+<!--
+For example:
+1. consider there are 4 {major.minor} versions 1.24, 1.25, 1.26, 1.27
+2. take the latest three, 1.25, 1.26, 1.27
+3. take the latest patch version for each, eg: 1.27.0, 1.27.1 << choose 1.27.1
+4. this is our latest stable set, eg: 1.25.5, 1.26.7, 1.27.1
+-->
 
+<!--
+1. get all changelogs as defined in Section
+2. filter where version key not defined in frontmatter (very old versions).
+   These will never be the latest stable and make later steps hard.
+3. group by major.minor (eg: 1.26, 1.27) as defined in Page Title.
+-->
+{{ $versioned_changelogs := (
+where (
+where $.Site.RegularPages "Section" "changelogs"
+) "Params.version" "!=" nil
+).GroupBy "Title"
+}}
+
+<!-- declare slice of latest patch versions for each major.minor -->
+{{ $latest_major_minors := slice }}
+
+<!-- add our latest major.minor to slice -->
+{{ range $versioned_changelogs }}
+{{ range first 1 (.Pages.ByParam "version").Reverse }}
+{{ $latest_major_minors = $latest_major_minors | append .Page }}
+{{ end }}
+{{ end }}
+
+{{ $latest_stables := first 3 (sort ($latest_major_minors).ByDate.Reverse) }}
+
+{{ $all_changelogs := where $.Site.Pages "Section" "changelogs" }}
+{{ $deprecated := $all_changelogs | complement $latest_stables }}
+
+{{ range $deprecated }}
 <div class="my-3">
   <h4>{{.Params.changelog_title}}</h4>
   <span>Released: {{.Date.UTC}}</span>
   <a href="{{.RelPermalink}}" target="_blank">Changelog</a>
 </div>
-
- {{ end }}{{end}}
+{{ end }}

--- a/layouts/shortcodes/latest-stable.html
+++ b/layouts/shortcodes/latest-stable.html
@@ -1,10 +1,41 @@
-{{ $changelogs := where $.Site.Pages "Section" "changelogs" }} 
-{{ range $changelogs.ByDate.Reverse }} 
-{{ if not (in .Params.tags "deprecated" )}}{{  if isset  .Params "version" }}
-<div class="my-3">
-<h4>{{.Params.changelog_title}}</h4>
-<span>Released: {{.Params.date.UTC}}</span>
-<a href="{{.RelPermalink}}">Changelog</a>
-</div>
+<!--
+For example:
+1. consider there are 4 {major.minor} versions 1.24, 1.25, 1.26, 1.27
+2. take the latest three, 1.25, 1.26, 1.27
+3. take the latest patch version for each, eg: 1.27.0, 1.27.1 << choose 1.27.1
+4. this is our latest stable set, eg: 1.25.5, 1.26.7, 1.27.1
+-->
 
-{{end}} {{ end }}{{end}}
+<!--
+1. get all changelogs as defined in Section
+2. filter where version key not defined in frontmatter (very old versions).
+   These will never be the latest stable and make later steps hard.
+3. group by major.minor (eg: 1.26, 1.27) as defined in Page Title.
+-->
+{{ $versioned_changelogs := (
+where (
+where $.Site.RegularPages "Section" "changelogs"
+) "Params.version" "!=" nil
+).GroupBy "Title"
+}}
+
+<!-- declare slice of latest patch versions for each major.minor -->
+{{ $latest_major_minors := slice }}
+
+<!-- add our latest major.minor to slice -->
+{{ range $versioned_changelogs }}
+{{ range first 1 (.Pages.ByParam "version").Reverse }}
+{{ $latest_major_minors = $latest_major_minors | append .Page }}
+{{ end }}
+{{ end }}
+
+{{ $latest_stables := first 3 (sort ($latest_major_minors).ByDate.Reverse) }}
+
+<!-- print out our template section for each stable version -->
+{{ range sort ($latest_stables).ByTitle.Reverse }}
+<div class="my-3">
+  <h4>{{.Params.changelog_title}}</h4>
+  <span>Released: {{.Params.date.UTC}}</span>
+  <a href="{{.RelPermalink}}">Changelog</a>
+</div>
+{{ end }}


### PR DESCRIPTION
This function can be removed: : https://github.com/spinnaker/buildtool/blob/master/dev/buildtool/changelog_commands.py#L552

This removes the need to add a tag `deprecated` to previous versions
during the release process.
Before this change when 1.27.1 is released, 1.27.0 changelog file needs
to be updated with `deprecated` tag.

Overall we can do this by leveraging some key ideas:
1. changelog's contain a `date: 2022-05-02 23:37:12 +0000` section in
   frontmatter that is never changed. This means a newer patch version
   for any `{major.minor}` will always have a newer `date`.
2. we only commit to maintaining (backporting) the latest
   3 {major.minor} versions/branches.