### PR TITLE
docs(changelog): Revise Changelog frontmatter keys

### DIFF
--- a/content/en/changelogs/1.0.0-changelog.md
+++ b/content/en/changelogs/1.0.0-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.0
-changelog_title: Version 1.0.0
+title: Spinnaker Release 1.0.0
 date: 2017-06-05 11:21:34 -0400
 tags:
   - changelogs
   - 1.0
+major_minor: 1.0
+version: 1.0.0
 ---
 
 - Initial release

--- a/content/en/changelogs/1.0.0-changelog.md
+++ b/content/en/changelogs/1.0.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.0.0
 date: 2017-06-05 11:21:34 -0400
-tags:
-  - changelogs
-  - 1.0
 major_minor: 1.0
 version: 1.0.0
 ---

--- a/content/en/changelogs/1.0.1-changelog.md
+++ b/content/en/changelogs/1.0.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.0.1
 date: 2017-06-12 20:33:32
-tags:
-  - changelogs
-  - 1.0
 major_minor: 1.0
 version: 1.0.1
 ---

--- a/content/en/changelogs/1.0.1-changelog.md
+++ b/content/en/changelogs/1.0.1-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.0
-changelog_title: Version 1.0.1
+title: Spinnaker Release 1.0.1
 date: 2017-06-12 20:33:32
 tags:
   - changelogs
   - 1.0
+major_minor: 1.0
+version: 1.0.1
 ---
 
 <script src="https://gist.github.com/spinnaker-release/b3515a47abbcdc86f0cfdc2bd6cb8a17.js"></script>

--- a/content/en/changelogs/1.1.0-changelog.md
+++ b/content/en/changelogs/1.1.0-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.1
-changelog_title: Version 1.1.0
+title: Spinnaker Release 1.1.0
 date: 2017-07-05 18:47:56
 tags:
   - changelogs
   - 1.1
+major_minor: 1.1
+version: 1.1.0
 ---
 
 <script src="https://gist.github.com/spinnaker-release/1b02cdba17f78c3dc9f4210d09610ac8.js"></script>

--- a/content/en/changelogs/1.1.0-changelog.md
+++ b/content/en/changelogs/1.1.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.1.0
 date: 2017-07-05 18:47:56
-tags:
-  - changelogs
-  - 1.1
 major_minor: 1.1
 version: 1.1.0
 ---

--- a/content/en/changelogs/1.1.1-changelog.md
+++ b/content/en/changelogs/1.1.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.1.1
 date: 2017-07-21 13:35:55
-tags:
-  - changelogs
-  - 1.1
 major_minor: 1.1
 version: 1.1.1
 ---

--- a/content/en/changelogs/1.1.1-changelog.md
+++ b/content/en/changelogs/1.1.1-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.1
-changelog_title: Version 1.1.1
+title: Spinnaker Release 1.1.1
 date: 2017-07-21 13:35:55
 tags:
   - changelogs
   - 1.1
+major_minor: 1.1
+version: 1.1.1
 ---
 
 <script src="https://gist.github.com/spinnaker-release/d223113b2967deb1272b5f8bffa7645a.js"></script>

--- a/content/en/changelogs/1.1.2-changelog.md
+++ b/content/en/changelogs/1.1.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.1.2
 date: 2017-07-27 21:42:06
-tags:
-  - changelogs
-  - 1.1
 major_minor: 1.1
 version: 1.1.2
 ---

--- a/content/en/changelogs/1.1.2-changelog.md
+++ b/content/en/changelogs/1.1.2-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.1
-changelog_title: Version 1.1.2
+title: Spinnaker Release 1.1.2
 date: 2017-07-27 21:42:06
 tags:
   - changelogs
   - 1.1
+major_minor: 1.1
+version: 1.1.2
 ---
 
 <script src="https://gist.github.com/spinnaker-release/83f03c39840317b473893da6abea7a0e.js"></script>

--- a/content/en/changelogs/1.10.0-changelog.md
+++ b/content/en/changelogs/1.10.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.0
 date: 2018-10-16 17:31:38
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10
 version: 1.10.0
 ---

--- a/content/en/changelogs/1.10.0-changelog.md
+++ b/content/en/changelogs/1.10.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.0
+title: Spinnaker Release 1.10.0
 date: 2018-10-16 17:31:38
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10
 version: 1.10.0
 ---
 

--- a/content/en/changelogs/1.10.1-changelog.md
+++ b/content/en/changelogs/1.10.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.1
 date: 2018-10-24 13:04:45
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10
 version: 1.10.1
 ---

--- a/content/en/changelogs/1.10.1-changelog.md
+++ b/content/en/changelogs/1.10.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.1
+title: Spinnaker Release 1.10.1
 date: 2018-10-24 13:04:45
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10
 version: 1.10.1
 ---
 

--- a/content/en/changelogs/1.10.10-changelog.md
+++ b/content/en/changelogs/1.10.10-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.10
+title: Spinnaker Release 1.10.10
 date: 2019-01-11 21:23:16
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10.10-changelog.md
 version: 1.10.10
 ---
 

--- a/content/en/changelogs/1.10.10-changelog.md
+++ b/content/en/changelogs/1.10.10-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.10
 date: 2019-01-11 21:23:16
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10.10-changelog.md
 version: 1.10.10
 ---

--- a/content/en/changelogs/1.10.11-changelog.md
+++ b/content/en/changelogs/1.10.11-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.11
+title: Spinnaker Release 1.10.11
 date: 2019-01-15 08:41:34
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10.11-changelog.md
 version: 1.10.11
 ---
 

--- a/content/en/changelogs/1.10.11-changelog.md
+++ b/content/en/changelogs/1.10.11-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.11
 date: 2019-01-15 08:41:34
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10.11-changelog.md
 version: 1.10.11
 ---

--- a/content/en/changelogs/1.10.12-changelog.md
+++ b/content/en/changelogs/1.10.12-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.12
 date: 2019-01-22 17:55:10
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10.12-changelog.md
 version: 1.10.12
 ---

--- a/content/en/changelogs/1.10.12-changelog.md
+++ b/content/en/changelogs/1.10.12-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.12
+title: Spinnaker Release 1.10.12
 date: 2019-01-22 17:55:10
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10.12-changelog.md
 version: 1.10.12
 ---
 

--- a/content/en/changelogs/1.10.13-changelog.md
+++ b/content/en/changelogs/1.10.13-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.13
 date: 2019-01-30 18:25:40
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10.13-changelog.md
 version: 1.10.13
 ---

--- a/content/en/changelogs/1.10.13-changelog.md
+++ b/content/en/changelogs/1.10.13-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.13
+title: Spinnaker Release 1.10.13
 date: 2019-01-30 18:25:40
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10.13-changelog.md
 version: 1.10.13
 ---
 

--- a/content/en/changelogs/1.10.14-changelog.md
+++ b/content/en/changelogs/1.10.14-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.14
 date: 2019-03-01 12:43:49
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10.14-changelog.md
 version: 1.10.14
 ---

--- a/content/en/changelogs/1.10.14-changelog.md
+++ b/content/en/changelogs/1.10.14-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.14
+title: Spinnaker Release 1.10.14
 date: 2019-03-01 12:43:49
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10.14-changelog.md
 version: 1.10.14
 ---
 

--- a/content/en/changelogs/1.10.2-changelog.md
+++ b/content/en/changelogs/1.10.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.2
 date: 2018-11-05 09:38:18
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10
 version: 1.10.2
 ---

--- a/content/en/changelogs/1.10.2-changelog.md
+++ b/content/en/changelogs/1.10.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.2
+title: Spinnaker Release 1.10.2
 date: 2018-11-05 09:38:18
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10
 version: 1.10.2
 ---
 

--- a/content/en/changelogs/1.10.3-changelog.md
+++ b/content/en/changelogs/1.10.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.3
+title: Spinnaker Release 1.10.3
 date: 2018-11-09 13:55:08
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10
 version: 1.10.3
 ---
 

--- a/content/en/changelogs/1.10.3-changelog.md
+++ b/content/en/changelogs/1.10.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.3
 date: 2018-11-09 13:55:08
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10
 version: 1.10.3
 ---

--- a/content/en/changelogs/1.10.4-changelog.md
+++ b/content/en/changelogs/1.10.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.4
+title: Spinnaker Release 1.10.4
 date: 2018-11-12 14:27:04
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10
 version: 1.10.4
 ---
 

--- a/content/en/changelogs/1.10.4-changelog.md
+++ b/content/en/changelogs/1.10.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.4
 date: 2018-11-12 14:27:04
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10
 version: 1.10.4
 ---

--- a/content/en/changelogs/1.10.5-changelog.md
+++ b/content/en/changelogs/1.10.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.5
 date: 2018-11-15 16:46:26
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10
 version: 1.10.5
 ---

--- a/content/en/changelogs/1.10.5-changelog.md
+++ b/content/en/changelogs/1.10.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.5
+title: Spinnaker Release 1.10.5
 date: 2018-11-15 16:46:26
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10
 version: 1.10.5
 ---
 

--- a/content/en/changelogs/1.10.6-changelog.md
+++ b/content/en/changelogs/1.10.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.6
 date: 2018-12-19 08:00:48
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10
 version: 1.10.6
 ---

--- a/content/en/changelogs/1.10.6-changelog.md
+++ b/content/en/changelogs/1.10.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.6
+title: Spinnaker Release 1.10.6
 date: 2018-12-19 08:00:48
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10
 version: 1.10.6
 ---
 

--- a/content/en/changelogs/1.10.7-changelog.md
+++ b/content/en/changelogs/1.10.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.7
 date: 2019-01-03 09:58:06
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10
 version: 1.10.7
 ---

--- a/content/en/changelogs/1.10.7-changelog.md
+++ b/content/en/changelogs/1.10.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.7
+title: Spinnaker Release 1.10.7
 date: 2019-01-03 09:58:06
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10
 version: 1.10.7
 ---
 

--- a/content/en/changelogs/1.10.8-changelog.md
+++ b/content/en/changelogs/1.10.8-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.8
 date: 2019-01-04 09:24:12
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10
 version: 1.10.8
 ---

--- a/content/en/changelogs/1.10.8-changelog.md
+++ b/content/en/changelogs/1.10.8-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.8
+title: Spinnaker Release 1.10.8
 date: 2019-01-04 09:24:12
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10
 version: 1.10.8
 ---
 

--- a/content/en/changelogs/1.10.9-changelog.md
+++ b/content/en/changelogs/1.10.9-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.10
-changelog_title: Version 1.10.9
+title: Spinnaker Release 1.10.9
 date: 2019-01-05 12:44:19
 tags:
   - changelogs
   - 1.10
+major_minor: 1.10
 version: 1.10.9
 ---
 

--- a/content/en/changelogs/1.10.9-changelog.md
+++ b/content/en/changelogs/1.10.9-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.10.9
 date: 2019-01-05 12:44:19
-tags:
-  - changelogs
-  - 1.10
 major_minor: 1.10
 version: 1.10.9
 ---

--- a/content/en/changelogs/1.11.0-changelog.md
+++ b/content/en/changelogs/1.11.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.0
 date: 2018-12-13 14:49:42
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11
 version: 1.11.0
 ---

--- a/content/en/changelogs/1.11.0-changelog.md
+++ b/content/en/changelogs/1.11.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.0
+title: Spinnaker Release 1.11.0
 date: 2018-12-13 14:49:42
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11
 version: 1.11.0
 ---
 

--- a/content/en/changelogs/1.11.1-changelog.md
+++ b/content/en/changelogs/1.11.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.1
+title: Spinnaker Release 1.11.1
 date: 2018-12-19 11:44:31
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11
 version: 1.11.1
 ---
 

--- a/content/en/changelogs/1.11.1-changelog.md
+++ b/content/en/changelogs/1.11.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.1
 date: 2018-12-19 11:44:31
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11
 version: 1.11.1
 ---

--- a/content/en/changelogs/1.11.10-changelog.md
+++ b/content/en/changelogs/1.11.10-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.10
 date: 2019-02-25 15:39:58
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11.10-changelog.md
 version: 1.11.10
 ---

--- a/content/en/changelogs/1.11.10-changelog.md
+++ b/content/en/changelogs/1.11.10-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.10
+title: Spinnaker Release 1.11.10
 date: 2019-02-25 15:39:58
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11.10-changelog.md
 version: 1.11.10
 ---
 

--- a/content/en/changelogs/1.11.11-changelog.md
+++ b/content/en/changelogs/1.11.11-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.11
+title: Spinnaker Release 1.11.11
 date: 2019-03-01 12:46:48
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11.11-changelog.md
 version: 1.11.11
 ---
 

--- a/content/en/changelogs/1.11.11-changelog.md
+++ b/content/en/changelogs/1.11.11-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.11
 date: 2019-03-01 12:46:48
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11.11-changelog.md
 version: 1.11.11
 ---

--- a/content/en/changelogs/1.11.12-changelog.md
+++ b/content/en/changelogs/1.11.12-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.12
+title: Spinnaker Release 1.11.12
 date: 2019-04-05 10:55:49
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11.12-changelog.md
 version: 1.11.12
 ---
 

--- a/content/en/changelogs/1.11.12-changelog.md
+++ b/content/en/changelogs/1.11.12-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.12
 date: 2019-04-05 10:55:49
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11.12-changelog.md
 version: 1.11.12
 ---

--- a/content/en/changelogs/1.11.13-changelog.md
+++ b/content/en/changelogs/1.11.13-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.13
 date: 2019-05-01 10:38:14
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11.13-changelog.md
 version: 1.11.13
 ---

--- a/content/en/changelogs/1.11.13-changelog.md
+++ b/content/en/changelogs/1.11.13-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.13
+title: Spinnaker Release 1.11.13
 date: 2019-05-01 10:38:14
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11.13-changelog.md
 version: 1.11.13
 ---
 

--- a/content/en/changelogs/1.11.2-changelog.md
+++ b/content/en/changelogs/1.11.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.2
+title: Spinnaker Release 1.11.2
 date: 2018-12-21 10:49:22
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11
 version: 1.11.2
 ---
 

--- a/content/en/changelogs/1.11.2-changelog.md
+++ b/content/en/changelogs/1.11.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.2
 date: 2018-12-21 10:49:22
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11
 version: 1.11.2
 ---

--- a/content/en/changelogs/1.11.3-changelog.md
+++ b/content/en/changelogs/1.11.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.3
+title: Spinnaker Release 1.11.3
 date: 2019-01-03 09:36:38
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11
 version: 1.11.3
 ---
 

--- a/content/en/changelogs/1.11.3-changelog.md
+++ b/content/en/changelogs/1.11.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.3
 date: 2019-01-03 09:36:38
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11
 version: 1.11.3
 ---

--- a/content/en/changelogs/1.11.4-changelog.md
+++ b/content/en/changelogs/1.11.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.4
+title: Spinnaker Release 1.11.4
 date: 2019-01-05 09:17:34
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11
 version: 1.11.4
 ---
 

--- a/content/en/changelogs/1.11.4-changelog.md
+++ b/content/en/changelogs/1.11.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.4
 date: 2019-01-05 09:17:34
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11
 version: 1.11.4
 ---

--- a/content/en/changelogs/1.11.5-changelog.md
+++ b/content/en/changelogs/1.11.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.5
 date: 2019-01-11 17:45:29
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11
 version: 1.11.5
 ---

--- a/content/en/changelogs/1.11.5-changelog.md
+++ b/content/en/changelogs/1.11.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.5
+title: Spinnaker Release 1.11.5
 date: 2019-01-11 17:45:29
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11
 version: 1.11.5
 ---
 

--- a/content/en/changelogs/1.11.6-changelog.md
+++ b/content/en/changelogs/1.11.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.6
 date: 2019-01-15 07:29:43
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11
 version: 1.11.6
 ---

--- a/content/en/changelogs/1.11.6-changelog.md
+++ b/content/en/changelogs/1.11.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.6
+title: Spinnaker Release 1.11.6
 date: 2019-01-15 07:29:43
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11
 version: 1.11.6
 ---
 

--- a/content/en/changelogs/1.11.7-changelog.md
+++ b/content/en/changelogs/1.11.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.7
 date: 2019-01-22 18:38:07
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11
 version: 1.11.7
 ---

--- a/content/en/changelogs/1.11.7-changelog.md
+++ b/content/en/changelogs/1.11.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.7
+title: Spinnaker Release 1.11.7
 date: 2019-01-22 18:38:07
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11
 version: 1.11.7
 ---
 

--- a/content/en/changelogs/1.11.8-changelog.md
+++ b/content/en/changelogs/1.11.8-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.8
 date: 2019-01-28 15:33:55
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11
 version: 1.11.8
 ---

--- a/content/en/changelogs/1.11.8-changelog.md
+++ b/content/en/changelogs/1.11.8-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.8
+title: Spinnaker Release 1.11.8
 date: 2019-01-28 15:33:55
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11
 version: 1.11.8
 ---
 

--- a/content/en/changelogs/1.11.9-changelog.md
+++ b/content/en/changelogs/1.11.9-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.11
-changelog_title: Version 1.11.9
+title: Spinnaker Release 1.11.9
 date: 2019-01-30 18:27:42
 tags:
   - changelogs
   - 1.11
+major_minor: 1.11
 version: 1.11.9
 ---
 

--- a/content/en/changelogs/1.11.9-changelog.md
+++ b/content/en/changelogs/1.11.9-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.11.9
 date: 2019-01-30 18:27:42
-tags:
-  - changelogs
-  - 1.11
 major_minor: 1.11
 version: 1.11.9
 ---

--- a/content/en/changelogs/1.12.0-changelog.md
+++ b/content/en/changelogs/1.12.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.0
+title: Spinnaker Release 1.12.0
 date: 2019-01-28 17:13:47
 tags:
   - chagelogs
   - 1.12
+major_minor: 1.12
 version: 1.12.0
 ---
 

--- a/content/en/changelogs/1.12.0-changelog.md
+++ b/content/en/changelogs/1.12.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.0
 date: 2019-01-28 17:13:47
-tags:
-  - chagelogs
-  - 1.12
 major_minor: 1.12
 version: 1.12.0
 ---

--- a/content/en/changelogs/1.12.1-changelog.md
+++ b/content/en/changelogs/1.12.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.1
 date: 2019-01-31 17:01:57
-tags:
-  - chagelogs
-  - 1.12
 major_minor: 1.12
 version: 1.12.1
 ---

--- a/content/en/changelogs/1.12.1-changelog.md
+++ b/content/en/changelogs/1.12.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.1
+title: Spinnaker Release 1.12.1
 date: 2019-01-31 17:01:57
 tags:
   - chagelogs
   - 1.12
+major_minor: 1.12
 version: 1.12.1
 ---
 

--- a/content/en/changelogs/1.12.10-changelog.md
+++ b/content/en/changelogs/1.12.10-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.10
 date: 2019-04-29 11:39:22
-tags:
-  - changelogs
-  - 1.12
 major_minor: 1.12.10-changelog.md
 version: 1.12.10
 ---

--- a/content/en/changelogs/1.12.10-changelog.md
+++ b/content/en/changelogs/1.12.10-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.10
+title: Spinnaker Release 1.12.10
 date: 2019-04-29 11:39:22
 tags:
   - changelogs
   - 1.12
+major_minor: 1.12.10-changelog.md
 version: 1.12.10
 ---
 

--- a/content/en/changelogs/1.12.11-changelog.md
+++ b/content/en/changelogs/1.12.11-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.11
 date: 2019-05-23 15:17:25
-tags:
-  - changelogs
-  - 1.12
 major_minor: 1.12.11-changelog.md
 version: 1.12.11
 ---

--- a/content/en/changelogs/1.12.11-changelog.md
+++ b/content/en/changelogs/1.12.11-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.11
+title: Spinnaker Release 1.12.11
 date: 2019-05-23 15:17:25
 tags:
   - changelogs
   - 1.12
+major_minor: 1.12.11-changelog.md
 version: 1.12.11
 ---
 

--- a/content/en/changelogs/1.12.12-changelog.md
+++ b/content/en/changelogs/1.12.12-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.12
+title: Spinnaker Release 1.12.12
 date: 2019-06-05 14:46:51
 tags:
   - changelogs
   - 1.12
+major_minor: 1.12.12-changelog.md
 version: 1.12.12
 ---
 

--- a/content/en/changelogs/1.12.12-changelog.md
+++ b/content/en/changelogs/1.12.12-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.12
 date: 2019-06-05 14:46:51
-tags:
-  - changelogs
-  - 1.12
 major_minor: 1.12.12-changelog.md
 version: 1.12.12
 ---

--- a/content/en/changelogs/1.12.13-changelog.md
+++ b/content/en/changelogs/1.12.13-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.13
+title: Spinnaker Release 1.12.13
 date: 2019-06-20 11:12:30
 tags:
   - changelogs
   - 1.12
+major_minor: 1.12.13-changelog.md
 version: 1.12.13
 ---
 

--- a/content/en/changelogs/1.12.13-changelog.md
+++ b/content/en/changelogs/1.12.13-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.13
 date: 2019-06-20 11:12:30
-tags:
-  - changelogs
-  - 1.12
 major_minor: 1.12.13-changelog.md
 version: 1.12.13
 ---

--- a/content/en/changelogs/1.12.14-changelog.md
+++ b/content/en/changelogs/1.12.14-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.14
 date: 2019-07-08 10:47:01
-tags:
-  - changelogs
-  - 1.12
 major_minor: 1.12.14-changelog.md
 version: 1.12.14
 ---

--- a/content/en/changelogs/1.12.14-changelog.md
+++ b/content/en/changelogs/1.12.14-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.14
+title: Spinnaker Release 1.12.14
 date: 2019-07-08 10:47:01
 tags:
   - changelogs
   - 1.12
+major_minor: 1.12.14-changelog.md
 version: 1.12.14
 ---
 

--- a/content/en/changelogs/1.12.2-changelog.md
+++ b/content/en/changelogs/1.12.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.2
+title: Spinnaker Release 1.12.2
 date: 2019-02-14 16:17:05
 tags:
   - chagelogs
   - 1.12
+major_minor: 1.12
 version: 1.12.2
 ---
 

--- a/content/en/changelogs/1.12.2-changelog.md
+++ b/content/en/changelogs/1.12.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.2
 date: 2019-02-14 16:17:05
-tags:
-  - chagelogs
-  - 1.12
 major_minor: 1.12
 version: 1.12.2
 ---

--- a/content/en/changelogs/1.12.3-changelog.md
+++ b/content/en/changelogs/1.12.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.3
+title: Spinnaker Release 1.12.3
 date: 2019-02-25 15:41:45
 tags:
   - chagelogs
   - 1.12
+major_minor: 1.12
 version: 1.12.3
 ---
 

--- a/content/en/changelogs/1.12.3-changelog.md
+++ b/content/en/changelogs/1.12.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.3
 date: 2019-02-25 15:41:45
-tags:
-  - chagelogs
-  - 1.12
 major_minor: 1.12
 version: 1.12.3
 ---

--- a/content/en/changelogs/1.12.4-changelog.md
+++ b/content/en/changelogs/1.12.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.4
 date: 2019-03-01 12:55:24
-tags:
-  - chagelogs
-  - 1.12
 major_minor: 1.12
 version: 1.12.4
 ---

--- a/content/en/changelogs/1.12.4-changelog.md
+++ b/content/en/changelogs/1.12.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.4
+title: Spinnaker Release 1.12.4
 date: 2019-03-01 12:55:24
 tags:
   - chagelogs
   - 1.12
+major_minor: 1.12
 version: 1.12.4
 ---
 

--- a/content/en/changelogs/1.12.5-changelog.md
+++ b/content/en/changelogs/1.12.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.5
+title: Spinnaker Release 1.12.5
 date: 2019-03-08 19:43:23
 tags:
   - chagelogs
   - 1.12
+major_minor: 1.12
 version: 1.12.5
 ---
 

--- a/content/en/changelogs/1.12.5-changelog.md
+++ b/content/en/changelogs/1.12.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.5
 date: 2019-03-08 19:43:23
-tags:
-  - chagelogs
-  - 1.12
 major_minor: 1.12
 version: 1.12.5
 ---

--- a/content/en/changelogs/1.12.6-changelog.md
+++ b/content/en/changelogs/1.12.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.6
+title: Spinnaker Release 1.12.6
 date: 2019-03-13 22:37:28
 tags:
   - changelogs
   - 1.12
+major_minor: 1.12
 version: 1.12.6
 ---
 

--- a/content/en/changelogs/1.12.6-changelog.md
+++ b/content/en/changelogs/1.12.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.6
 date: 2019-03-13 22:37:28
-tags:
-  - changelogs
-  - 1.12
 major_minor: 1.12
 version: 1.12.6
 ---

--- a/content/en/changelogs/1.12.7-changelog.md
+++ b/content/en/changelogs/1.12.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.7
+title: Spinnaker Release 1.12.7
 date: 2019-03-22 10:16:58
 tags:
   - changelogs
   - 1.12
+major_minor: 1.12
 version: 1.12.7
 ---
 

--- a/content/en/changelogs/1.12.7-changelog.md
+++ b/content/en/changelogs/1.12.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.7
 date: 2019-03-22 10:16:58
-tags:
-  - changelogs
-  - 1.12
 major_minor: 1.12
 version: 1.12.7
 ---

--- a/content/en/changelogs/1.12.8-changelog.md
+++ b/content/en/changelogs/1.12.8-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.8
 date: 2019-04-01 09:48:34
-tags:
-  - changelogs
-  - 1.12
 major_minor: 1.12
 version: 1.12.8
 ---

--- a/content/en/changelogs/1.12.8-changelog.md
+++ b/content/en/changelogs/1.12.8-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.8
+title: Spinnaker Release 1.12.8
 date: 2019-04-01 09:48:34
 tags:
   - changelogs
   - 1.12
+major_minor: 1.12
 version: 1.12.8
 ---
 

--- a/content/en/changelogs/1.12.9-changelog.md
+++ b/content/en/changelogs/1.12.9-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.12
-changelog_title: Version 1.12.9
+title: Spinnaker Release 1.12.9
 date: 2019-04-05 10:11:53
 tags:
   - changelogs
   - 1.12
+major_minor: 1.12
 version: 1.12.9
 ---
 

--- a/content/en/changelogs/1.12.9-changelog.md
+++ b/content/en/changelogs/1.12.9-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.12.9
 date: 2019-04-05 10:11:53
-tags:
-  - changelogs
-  - 1.12
 major_minor: 1.12
 version: 1.12.9
 ---

--- a/content/en/changelogs/1.13.0-changelog.md
+++ b/content/en/changelogs/1.13.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.0
+title: Spinnaker Release 1.13.0
 date: 2019-03-25 15:38:07
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13
 version: 1.13.0
 ---
 

--- a/content/en/changelogs/1.13.0-changelog.md
+++ b/content/en/changelogs/1.13.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.0
 date: 2019-03-25 15:38:07
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13
 version: 1.13.0
 ---

--- a/content/en/changelogs/1.13.1-changelog.md
+++ b/content/en/changelogs/1.13.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.1
 date: 2019-04-09 10:31:22
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13
 version: 1.13.1
 ---

--- a/content/en/changelogs/1.13.1-changelog.md
+++ b/content/en/changelogs/1.13.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.1
+title: Spinnaker Release 1.13.1
 date: 2019-04-09 10:31:22
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13
 version: 1.13.1
 ---
 

--- a/content/en/changelogs/1.13.10-changelog.md
+++ b/content/en/changelogs/1.13.10-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.10
+title: Spinnaker Release 1.13.10
 date: 2019-06-20 11:31:40
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13.10-changelog.md
 version: 1.13.10
 ---
 

--- a/content/en/changelogs/1.13.10-changelog.md
+++ b/content/en/changelogs/1.13.10-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.10
 date: 2019-06-20 11:31:40
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13.10-changelog.md
 version: 1.13.10
 ---

--- a/content/en/changelogs/1.13.11-changelog.md
+++ b/content/en/changelogs/1.13.11-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.11
+title: Spinnaker Release 1.13.11
 date: 2019-07-08 09:56:56
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13.11-changelog.md
 version: 1.13.11
 ---
 

--- a/content/en/changelogs/1.13.11-changelog.md
+++ b/content/en/changelogs/1.13.11-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.11
 date: 2019-07-08 09:56:56
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13.11-changelog.md
 version: 1.13.11
 ---

--- a/content/en/changelogs/1.13.12-changelog.md
+++ b/content/en/changelogs/1.13.12-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.12
 date: 2019-07-29 14:19:09
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13.12-changelog.md
 version: 1.13.12
 ---

--- a/content/en/changelogs/1.13.12-changelog.md
+++ b/content/en/changelogs/1.13.12-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.12
+title: Spinnaker Release 1.13.12
 date: 2019-07-29 14:19:09
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13.12-changelog.md
 version: 1.13.12
 ---
 

--- a/content/en/changelogs/1.13.2-changelog.md
+++ b/content/en/changelogs/1.13.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.2
+title: Spinnaker Release 1.13.2
 date: 2019-04-05 11:46:16
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13
 version: 1.13.2
 ---
 

--- a/content/en/changelogs/1.13.2-changelog.md
+++ b/content/en/changelogs/1.13.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.2
 date: 2019-04-05 11:46:16
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13
 version: 1.13.2
 ---

--- a/content/en/changelogs/1.13.3-changelog.md
+++ b/content/en/changelogs/1.13.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.3
+title: Spinnaker Release 1.13.3
 date: 2019-04-09 10:11:54
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13
 version: 1.13.3
 ---
 

--- a/content/en/changelogs/1.13.3-changelog.md
+++ b/content/en/changelogs/1.13.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.3
 date: 2019-04-09 10:11:54
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13
 version: 1.13.3
 ---

--- a/content/en/changelogs/1.13.4-changelog.md
+++ b/content/en/changelogs/1.13.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.4
+title: Spinnaker Release 1.13.4
 date: 2019-04-15 13:22:53
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13
 version: 1.13.4
 ---
 

--- a/content/en/changelogs/1.13.4-changelog.md
+++ b/content/en/changelogs/1.13.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.4
 date: 2019-04-15 13:22:53
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13
 version: 1.13.4
 ---

--- a/content/en/changelogs/1.13.5-changelog.md
+++ b/content/en/changelogs/1.13.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.5
+title: Spinnaker Release 1.13.5
 date: 2019-04-22 10:32:39
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13
 version: 1.13.5
 ---
 

--- a/content/en/changelogs/1.13.5-changelog.md
+++ b/content/en/changelogs/1.13.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.5
 date: 2019-04-22 10:32:39
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13
 version: 1.13.5
 ---

--- a/content/en/changelogs/1.13.6-changelog.md
+++ b/content/en/changelogs/1.13.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.6
+title: Spinnaker Release 1.13.6
 date: 2019-04-29 11:35:20
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13
 version: 1.13.6
 ---
 

--- a/content/en/changelogs/1.13.6-changelog.md
+++ b/content/en/changelogs/1.13.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.6
 date: 2019-04-29 11:35:20
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13
 version: 1.13.6
 ---

--- a/content/en/changelogs/1.13.7-changelog.md
+++ b/content/en/changelogs/1.13.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.7
+title: Spinnaker Release 1.13.7
 date: 2019-05-16 13:49:24
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13
 version: 1.13.7
 ---
 

--- a/content/en/changelogs/1.13.7-changelog.md
+++ b/content/en/changelogs/1.13.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.7
 date: 2019-05-16 13:49:24
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13
 version: 1.13.7
 ---

--- a/content/en/changelogs/1.13.8-changelog.md
+++ b/content/en/changelogs/1.13.8-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.8
 date: 2019-05-23 15:27:05
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13
 version: 1.13.8
 ---

--- a/content/en/changelogs/1.13.8-changelog.md
+++ b/content/en/changelogs/1.13.8-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.8
+title: Spinnaker Release 1.13.8
 date: 2019-05-23 15:27:05
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13
 version: 1.13.8
 ---
 

--- a/content/en/changelogs/1.13.9-changelog.md
+++ b/content/en/changelogs/1.13.9-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.13
-changelog_title: Version 1.13.9
+title: Spinnaker Release 1.13.9
 date: 2019-06-10 14:50:42
 tags:
   - changelogs
   - 1.13
+major_minor: 1.13
 version: 1.13.9
 ---
 

--- a/content/en/changelogs/1.13.9-changelog.md
+++ b/content/en/changelogs/1.13.9-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.13.9
 date: 2019-06-10 14:50:42
-tags:
-  - changelogs
-  - 1.13
 major_minor: 1.13
 version: 1.13.9
 ---

--- a/content/en/changelogs/1.14.0-changelog.md
+++ b/content/en/changelogs/1.14.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.0
+title: Spinnaker Release 1.14.0
 date: 2019-05-20 15:28:53
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14
 version: 1.14.0
 ---
 

--- a/content/en/changelogs/1.14.0-changelog.md
+++ b/content/en/changelogs/1.14.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.0
 date: 2019-05-20 15:28:53
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14
 version: 1.14.0
 ---

--- a/content/en/changelogs/1.14.1-changelog.md
+++ b/content/en/changelogs/1.14.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.1
+title: Spinnaker Release 1.14.1
 date: 2019-05-24 11:17:23
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14
 version: 1.14.1
 ---
 

--- a/content/en/changelogs/1.14.1-changelog.md
+++ b/content/en/changelogs/1.14.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.1
 date: 2019-05-24 11:17:23
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14
 version: 1.14.1
 ---

--- a/content/en/changelogs/1.14.10-changelog.md
+++ b/content/en/changelogs/1.14.10-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.10
+title: Spinnaker Release 1.14.10
 date: 2019-07-18 12:07:45
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14.10-changelog.md
 version: 1.14.10
 ---
 

--- a/content/en/changelogs/1.14.10-changelog.md
+++ b/content/en/changelogs/1.14.10-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.10
 date: 2019-07-18 12:07:45
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14.10-changelog.md
 version: 1.14.10
 ---

--- a/content/en/changelogs/1.14.11-changelog.md
+++ b/content/en/changelogs/1.14.11-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.11
+title: Spinnaker Release 1.14.11
 date: 2019-07-23 17:50:37
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14.11-changelog.md
 version: 1.14.11
 ---
 

--- a/content/en/changelogs/1.14.11-changelog.md
+++ b/content/en/changelogs/1.14.11-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.11
 date: 2019-07-23 17:50:37
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14.11-changelog.md
 version: 1.14.11
 ---

--- a/content/en/changelogs/1.14.12-changelog.md
+++ b/content/en/changelogs/1.14.12-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.12
 date: 2019-07-29 13:41:43
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14.12-changelog.md
 version: 1.14.12
 ---

--- a/content/en/changelogs/1.14.12-changelog.md
+++ b/content/en/changelogs/1.14.12-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.12
+title: Spinnaker Release 1.14.12
 date: 2019-07-29 13:41:43
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14.12-changelog.md
 version: 1.14.12
 ---
 

--- a/content/en/changelogs/1.14.13-changelog.md
+++ b/content/en/changelogs/1.14.13-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.13
+title: Spinnaker Release 1.14.13
 date: 2019-08-05 10:39:41
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14.13-changelog.md
 version: 1.14.13
 ---
 

--- a/content/en/changelogs/1.14.13-changelog.md
+++ b/content/en/changelogs/1.14.13-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.13
 date: 2019-08-05 10:39:41
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14.13-changelog.md
 version: 1.14.13
 ---

--- a/content/en/changelogs/1.14.14-changelog.md
+++ b/content/en/changelogs/1.14.14-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.14
 date: 2019-08-14 09:38:01
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14.14-changelog.md
 version: 1.14.14
 ---

--- a/content/en/changelogs/1.14.14-changelog.md
+++ b/content/en/changelogs/1.14.14-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.14
+title: Spinnaker Release 1.14.14
 date: 2019-08-14 09:38:01
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14.14-changelog.md
 version: 1.14.14
 ---
 

--- a/content/en/changelogs/1.14.15-changelog.md
+++ b/content/en/changelogs/1.14.15-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.15
+title: Spinnaker Release 1.14.15
 date: 2019-09-16 14:09:59
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14.15-changelog.md
 version: 1.14.15
 ---
 

--- a/content/en/changelogs/1.14.15-changelog.md
+++ b/content/en/changelogs/1.14.15-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.15
 date: 2019-09-16 14:09:59
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14.15-changelog.md
 version: 1.14.15
 ---

--- a/content/en/changelogs/1.14.2-changelog.md
+++ b/content/en/changelogs/1.14.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.2
+title: Spinnaker Release 1.14.2
 date: 2019-05-28 14:57:44
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14
 version: 1.14.2
 ---
 

--- a/content/en/changelogs/1.14.2-changelog.md
+++ b/content/en/changelogs/1.14.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.2
 date: 2019-05-28 14:57:44
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14
 version: 1.14.2
 ---

--- a/content/en/changelogs/1.14.3-changelog.md
+++ b/content/en/changelogs/1.14.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.3
 date: 2019-06-04 11:15:15
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14
 version: 1.14.3
 ---

--- a/content/en/changelogs/1.14.3-changelog.md
+++ b/content/en/changelogs/1.14.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.3
+title: Spinnaker Release 1.14.3
 date: 2019-06-04 11:15:15
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14
 version: 1.14.3
 ---
 

--- a/content/en/changelogs/1.14.4-changelog.md
+++ b/content/en/changelogs/1.14.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.4
 date: 2019-06-10 12:35:56
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14
 version: 1.14.4
 ---

--- a/content/en/changelogs/1.14.4-changelog.md
+++ b/content/en/changelogs/1.14.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.4
+title: Spinnaker Release 1.14.4
 date: 2019-06-10 12:35:56
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14
 version: 1.14.4
 ---
 

--- a/content/en/changelogs/1.14.5-changelog.md
+++ b/content/en/changelogs/1.14.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.5
+title: Spinnaker Release 1.14.5
 date: 2019-06-12 10:23:28
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14
 version: 1.14.5
 ---
 

--- a/content/en/changelogs/1.14.5-changelog.md
+++ b/content/en/changelogs/1.14.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.5
 date: 2019-06-12 10:23:28
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14
 version: 1.14.5
 ---

--- a/content/en/changelogs/1.14.6-changelog.md
+++ b/content/en/changelogs/1.14.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.6
+title: Spinnaker Release 1.14.6
 date: 2019-06-17 12:46:02
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14
 version: 1.14.6
 ---
 

--- a/content/en/changelogs/1.14.6-changelog.md
+++ b/content/en/changelogs/1.14.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.6
 date: 2019-06-17 12:46:02
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14
 version: 1.14.6
 ---

--- a/content/en/changelogs/1.14.7-changelog.md
+++ b/content/en/changelogs/1.14.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.7
 date: 2019-06-24 10:03:33
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14
 version: 1.14.7
 ---

--- a/content/en/changelogs/1.14.7-changelog.md
+++ b/content/en/changelogs/1.14.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.7
+title: Spinnaker Release 1.14.7
 date: 2019-06-24 10:03:33
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14
 version: 1.14.7
 ---
 

--- a/content/en/changelogs/1.14.8-changelog.md
+++ b/content/en/changelogs/1.14.8-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.8
 date: 2019-07-01 10:14:34
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14
 version: 1.14.8
 ---

--- a/content/en/changelogs/1.14.8-changelog.md
+++ b/content/en/changelogs/1.14.8-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.8
+title: Spinnaker Release 1.14.8
 date: 2019-07-01 10:14:34
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14
 version: 1.14.8
 ---
 

--- a/content/en/changelogs/1.14.9-changelog.md
+++ b/content/en/changelogs/1.14.9-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.14.9
 date: 2019-07-08 17:11:13
-tags:
-  - changelogs
-  - 1.14
 major_minor: 1.14
 version: 1.14.9
 ---

--- a/content/en/changelogs/1.14.9-changelog.md
+++ b/content/en/changelogs/1.14.9-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.14
-changelog_title: Version 1.14.9
+title: Spinnaker Release 1.14.9
 date: 2019-07-08 17:11:13
 tags:
   - changelogs
   - 1.14
+major_minor: 1.14
 version: 1.14.9
 ---
 

--- a/content/en/changelogs/1.15.0-changelog.md
+++ b/content/en/changelogs/1.15.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.15
-changelog_title: Version 1.15.0
+title: Spinnaker Release 1.15.0
 date: 2019-07-19 13:28:47
 tags:
   - changelogs
   - 1.15
+major_minor: 1.15
 version: 1.15.0
 ---
 

--- a/content/en/changelogs/1.15.0-changelog.md
+++ b/content/en/changelogs/1.15.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.15.0
 date: 2019-07-19 13:28:47
-tags:
-  - changelogs
-  - 1.15
 major_minor: 1.15
 version: 1.15.0
 ---

--- a/content/en/changelogs/1.15.1-changelog.md
+++ b/content/en/changelogs/1.15.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.15
-changelog_title: Version 1.15.1
+title: Spinnaker Release 1.15.1
 date: 2019-07-29 13:04:12
 tags:
   - changelogs
   - 1.15
+major_minor: 1.15
 version: 1.15.1
 ---
 

--- a/content/en/changelogs/1.15.1-changelog.md
+++ b/content/en/changelogs/1.15.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.15.1
 date: 2019-07-29 13:04:12
-tags:
-  - changelogs
-  - 1.15
 major_minor: 1.15
 version: 1.15.1
 ---

--- a/content/en/changelogs/1.15.2-changelog.md
+++ b/content/en/changelogs/1.15.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.15
-changelog_title: Version 1.15.2
+title: Spinnaker Release 1.15.2
 date: 2019-08-12 16:49:02
 tags:
   - changelogs
   - 1.15
+major_minor: 1.15
 version: 1.15.2
 ---
 

--- a/content/en/changelogs/1.15.2-changelog.md
+++ b/content/en/changelogs/1.15.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.15.2
 date: 2019-08-12 16:49:02
-tags:
-  - changelogs
-  - 1.15
 major_minor: 1.15
 version: 1.15.2
 ---

--- a/content/en/changelogs/1.15.3-changelog.md
+++ b/content/en/changelogs/1.15.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.15
-changelog_title: Version 1.15.3
+title: Spinnaker Release 1.15.3
 date: 2019-08-26 17:09:31
 tags:
   - changelogs
   - 1.15
+major_minor: 1.15
 version: 1.15.3
 ---
 

--- a/content/en/changelogs/1.15.3-changelog.md
+++ b/content/en/changelogs/1.15.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.15.3
 date: 2019-08-26 17:09:31
-tags:
-  - changelogs
-  - 1.15
 major_minor: 1.15
 version: 1.15.3
 ---

--- a/content/en/changelogs/1.15.4-changelog.md
+++ b/content/en/changelogs/1.15.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.15
-changelog_title: Version 1.15.4
+title: Spinnaker Release 1.15.4
 date: 2019-09-17 13:36:04
 tags:
   - changelogs
   - 1.15
+major_minor: 1.15
 version: 1.15.4
 ---
 

--- a/content/en/changelogs/1.15.4-changelog.md
+++ b/content/en/changelogs/1.15.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.15.4
 date: 2019-09-17 13:36:04
-tags:
-  - changelogs
-  - 1.15
 major_minor: 1.15
 version: 1.15.4
 ---

--- a/content/en/changelogs/1.15.5-changelog.md
+++ b/content/en/changelogs/1.15.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.15.5
 date: 2019-10-01 17:12:01
-tags:
-  - changelogs
-  - 1.15
 major_minor: 1.15
 version: 1.15.5
 ---

--- a/content/en/changelogs/1.15.5-changelog.md
+++ b/content/en/changelogs/1.15.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.15
-changelog_title: Version 1.15.5
+title: Spinnaker Release 1.15.5
 date: 2019-10-01 17:12:01
 tags:
   - changelogs
   - 1.15
+major_minor: 1.15
 version: 1.15.5
 ---
 

--- a/content/en/changelogs/1.15.6-changelog.md
+++ b/content/en/changelogs/1.15.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.15
-changelog_title: Version 1.15.6
+title: Spinnaker Release 1.15.6
 date: 2019-10-23 16:58:57
 tags:
   - changelogs
   - 1.15
+major_minor: 1.15
 version: 1.15.6
 ---
 

--- a/content/en/changelogs/1.15.6-changelog.md
+++ b/content/en/changelogs/1.15.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.15.6
 date: 2019-10-23 16:58:57
-tags:
-  - changelogs
-  - 1.15
 major_minor: 1.15
 version: 1.15.6
 ---

--- a/content/en/changelogs/1.15.7-changelog.md
+++ b/content/en/changelogs/1.15.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.15
-changelog_title: Version 1.15.7
+title: Spinnaker Release 1.15.7
 date: 2019-12-03 11:41:43
 tags:
   - changelogs
   - 1.15
+major_minor: 1.15
 version: 1.15.7
 ---
 

--- a/content/en/changelogs/1.15.7-changelog.md
+++ b/content/en/changelogs/1.15.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.15.7
 date: 2019-12-03 11:41:43
-tags:
-  - changelogs
-  - 1.15
 major_minor: 1.15
 version: 1.15.7
 ---

--- a/content/en/changelogs/1.16.0-changelog.md
+++ b/content/en/changelogs/1.16.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.16
-changelog_title: Version 1.16.0
+title: Spinnaker Release 1.16.0
 date: 2019-09-09 10:52:30
 tags:
   - changelogs
   - 1.16
+major_minor: 1.16
 version: 1.16.0
 ---
 

--- a/content/en/changelogs/1.16.0-changelog.md
+++ b/content/en/changelogs/1.16.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.16.0
 date: 2019-09-09 10:52:30
-tags:
-  - changelogs
-  - 1.16
 major_minor: 1.16
 version: 1.16.0
 ---

--- a/content/en/changelogs/1.16.1-changelog.md
+++ b/content/en/changelogs/1.16.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.16
-changelog_title: Version 1.16.1
+title: Spinnaker Release 1.16.1
 date: 2019-09-17 13:48:16
 tags:
   - changelogs
   - 1.16
+major_minor: 1.16
 version: 1.16.1
 ---
 

--- a/content/en/changelogs/1.16.1-changelog.md
+++ b/content/en/changelogs/1.16.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.16.1
 date: 2019-09-17 13:48:16
-tags:
-  - changelogs
-  - 1.16
 major_minor: 1.16
 version: 1.16.1
 ---

--- a/content/en/changelogs/1.16.2-changelog.md
+++ b/content/en/changelogs/1.16.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.16
-changelog_title: Version 1.16.2
+title: Spinnaker Release 1.16.2
 date: 2019-10-01 17:08:45
 tags:
   - changelogs
   - 1.16
+major_minor: 1.16
 version: 1.16.2
 ---
 

--- a/content/en/changelogs/1.16.2-changelog.md
+++ b/content/en/changelogs/1.16.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.16.2
 date: 2019-10-01 17:08:45
-tags:
-  - changelogs
-  - 1.16
 major_minor: 1.16
 version: 1.16.2
 ---

--- a/content/en/changelogs/1.16.3-changelog.md
+++ b/content/en/changelogs/1.16.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.16
-changelog_title: Version 1.16.3
+title: Spinnaker Release 1.16.3
 date: 2019-10-14 15:07:32
 tags:
   - changelogs
   - 1.16
+major_minor: 1.16
 version: 1.16.3
 ---
 

--- a/content/en/changelogs/1.16.3-changelog.md
+++ b/content/en/changelogs/1.16.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.16.3
 date: 2019-10-14 15:07:32
-tags:
-  - changelogs
-  - 1.16
 major_minor: 1.16
 version: 1.16.3
 ---

--- a/content/en/changelogs/1.16.4-changelog.md
+++ b/content/en/changelogs/1.16.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.16.4
 date: 2019-10-23 16:53:30
-tags:
-  - changelogs
-  - 1.16
 major_minor: 1.16
 version: 1.16.4
 ---

--- a/content/en/changelogs/1.16.4-changelog.md
+++ b/content/en/changelogs/1.16.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.16
-changelog_title: Version 1.16.4
+title: Spinnaker Release 1.16.4
 date: 2019-10-23 16:53:30
 tags:
   - changelogs
   - 1.16
+major_minor: 1.16
 version: 1.16.4
 ---
 

--- a/content/en/changelogs/1.16.5-changelog.md
+++ b/content/en/changelogs/1.16.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.16.5
 date: 2019-11-11 13:59:16
-tags:
-  - changelogs
-  - 1.16
 major_minor: 1.16
 version: 1.16.5
 ---

--- a/content/en/changelogs/1.16.5-changelog.md
+++ b/content/en/changelogs/1.16.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.16
-changelog_title: Version 1.16.5
+title: Spinnaker Release 1.16.5
 date: 2019-11-11 13:59:16
 tags:
   - changelogs
   - 1.16
+major_minor: 1.16
 version: 1.16.5
 ---
 

--- a/content/en/changelogs/1.16.6-changelog.md
+++ b/content/en/changelogs/1.16.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.16.6
 date: 2019-12-03 10:37:55
-tags:
-  - changelogs
-  - 1.16
 major_minor: 1.16
 version: 1.16.6
 ---

--- a/content/en/changelogs/1.16.6-changelog.md
+++ b/content/en/changelogs/1.16.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.16
-changelog_title: Version 1.16.6
+title: Spinnaker Release 1.16.6
 date: 2019-12-03 10:37:55
 tags:
   - changelogs
   - 1.16
+major_minor: 1.16
 version: 1.16.6
 ---
 

--- a/content/en/changelogs/1.16.7-changelog.md
+++ b/content/en/changelogs/1.16.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.16.7
 date: 2020-03-09 19:34:42 +0000
-tags:
-  - changelogs
-  - 1.16
 major_minor: 1.16
 version: 1.16.7
 ---

--- a/content/en/changelogs/1.16.7-changelog.md
+++ b/content/en/changelogs/1.16.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.16
-changelog_title: Version 1.16.7
+title: Spinnaker Release 1.16.7
 date: 2020-03-09 19:34:42 +0000
 tags:
   - changelogs
   - 1.16
+major_minor: 1.16
 version: 1.16.7
 ---
 

--- a/content/en/changelogs/1.17.0-changelog.md
+++ b/content/en/changelogs/1.17.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.17.0
 date: 2019-11-04 14:07:43
-tags:
-  - changelogs
-  - 1.17
 major_minor: 1.17
 version: 1.17.0
 ---

--- a/content/en/changelogs/1.17.0-changelog.md
+++ b/content/en/changelogs/1.17.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.17
-changelog_title: Version 1.17.0
+title: Spinnaker Release 1.17.0
 date: 2019-11-04 14:07:43
 tags:
   - changelogs
   - 1.17
+major_minor: 1.17
 version: 1.17.0
 ---
 

--- a/content/en/changelogs/1.17.1-changelog.md
+++ b/content/en/changelogs/1.17.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.17.1
 date: 2019-11-11 12:45:00
-tags:
-  - changelogs
-  - 1.17
 major_minor: 1.17
 version: 1.17.1
 ---

--- a/content/en/changelogs/1.17.1-changelog.md
+++ b/content/en/changelogs/1.17.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.17
-changelog_title: Version 1.17.1
+title: Spinnaker Release 1.17.1
 date: 2019-11-11 12:45:00
 tags:
   - changelogs
   - 1.17
+major_minor: 1.17
 version: 1.17.1
 ---
 

--- a/content/en/changelogs/1.17.10-changelog.md
+++ b/content/en/changelogs/1.17.10-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.17
-changelog_title: Version 1.17.10
+title: Spinnaker Release 1.17.10
 date: 2020-04-03 18:52:34 +0000
 tags:
   - changelogs
   - 1.17
+major_minor: 1.17.10-changelog.md
 version: 1.17.10
 ---
 

--- a/content/en/changelogs/1.17.10-changelog.md
+++ b/content/en/changelogs/1.17.10-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.17.10
 date: 2020-04-03 18:52:34 +0000
-tags:
-  - changelogs
-  - 1.17
 major_minor: 1.17.10-changelog.md
 version: 1.17.10
 ---

--- a/content/en/changelogs/1.17.2-changelog.md
+++ b/content/en/changelogs/1.17.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.17.2
 date: 2019-11-20 11:15:31
-tags:
-  - changelogs
-  - 1.17
 major_minor: 1.17
 version: 1.17.2
 ---

--- a/content/en/changelogs/1.17.2-changelog.md
+++ b/content/en/changelogs/1.17.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.17
-changelog_title: Version 1.17.2
+title: Spinnaker Release 1.17.2
 date: 2019-11-20 11:15:31
 tags:
   - changelogs
   - 1.17
+major_minor: 1.17
 version: 1.17.2
 ---
 

--- a/content/en/changelogs/1.17.3-changelog.md
+++ b/content/en/changelogs/1.17.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.17.3
 date: 2019-12-03 08:51:01
-tags:
-  - changelogs
-  - 1.17
 major_minor: 1.17
 version: 1.17.3
 ---

--- a/content/en/changelogs/1.17.3-changelog.md
+++ b/content/en/changelogs/1.17.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.17
-changelog_title: Version 1.17.3
+title: Spinnaker Release 1.17.3
 date: 2019-12-03 08:51:01
 tags:
   - changelogs
   - 1.17
+major_minor: 1.17
 version: 1.17.3
 ---
 

--- a/content/en/changelogs/1.17.4-changelog.md
+++ b/content/en/changelogs/1.17.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.17.4
 date: 2019-12-12 15:31:46 +0000
-tags:
-  - changelogs
-  - 1.17
 major_minor: 1.17
 version: 1.17.4
 ---

--- a/content/en/changelogs/1.17.4-changelog.md
+++ b/content/en/changelogs/1.17.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.17
-changelog_title: Version 1.17.4
+title: Spinnaker Release 1.17.4
 date: 2019-12-12 15:31:46 +0000
 tags:
   - changelogs
   - 1.17
+major_minor: 1.17
 version: 1.17.4
 ---
 

--- a/content/en/changelogs/1.17.5-changelog.md
+++ b/content/en/changelogs/1.17.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.17
-changelog_title: Version 1.17.5
+title: Spinnaker Release 1.17.5
 date: 2019-12-16 21:21:31 +0000
 tags:
   - changelogs
   - 1.17
+major_minor: 1.17
 version: 1.17.5
 ---
 

--- a/content/en/changelogs/1.17.5-changelog.md
+++ b/content/en/changelogs/1.17.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.17.5
 date: 2019-12-16 21:21:31 +0000
-tags:
-  - changelogs
-  - 1.17
 major_minor: 1.17
 version: 1.17.5
 ---

--- a/content/en/changelogs/1.17.6-changelog.md
+++ b/content/en/changelogs/1.17.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.17
-changelog_title: Version 1.17.6
+title: Spinnaker Release 1.17.6
 date: 2020-01-14 14:19:54 +0000
 tags:
   - changelogs
   - 1.17
+major_minor: 1.17
 version: 1.17.6
 ---
 

--- a/content/en/changelogs/1.17.6-changelog.md
+++ b/content/en/changelogs/1.17.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.17.6
 date: 2020-01-14 14:19:54 +0000
-tags:
-  - changelogs
-  - 1.17
 major_minor: 1.17
 version: 1.17.6
 ---

--- a/content/en/changelogs/1.17.7-changelog.md
+++ b/content/en/changelogs/1.17.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.17.7
 date: 2020-03-09 19:37:53 +0000
-tags:
-  - changelogs
-  - 1.17
 major_minor: 1.17
 version: 1.17.7
 ---

--- a/content/en/changelogs/1.17.7-changelog.md
+++ b/content/en/changelogs/1.17.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.17
-changelog_title: Version 1.17.7
+title: Spinnaker Release 1.17.7
 date: 2020-03-09 19:37:53 +0000
 tags:
   - changelogs
   - 1.17
+major_minor: 1.17
 version: 1.17.7
 ---
 

--- a/content/en/changelogs/1.17.8-changelog.md
+++ b/content/en/changelogs/1.17.8-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.17.8
 date: 2020-03-20 20:17:31 +0000
-tags:
-  - changelogs
-  - 1.17
 major_minor: 1.17
 version: 1.17.8
 ---

--- a/content/en/changelogs/1.17.8-changelog.md
+++ b/content/en/changelogs/1.17.8-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.17
-changelog_title: Version 1.17.8
+title: Spinnaker Release 1.17.8
 date: 2020-03-20 20:17:31 +0000
 tags:
   - changelogs
   - 1.17
+major_minor: 1.17
 version: 1.17.8
 ---
 

--- a/content/en/changelogs/1.17.9-changelog.md
+++ b/content/en/changelogs/1.17.9-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.17.9
 date: 2020-03-30 20:54:12 +0000
-tags:
-  - changelogs
-  - 1.17
 major_minor: 1.17
 version: 1.17.9
 ---

--- a/content/en/changelogs/1.17.9-changelog.md
+++ b/content/en/changelogs/1.17.9-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.17
-changelog_title: Version 1.17.9
+title: Spinnaker Release 1.17.9
 date: 2020-03-30 20:54:12 +0000
 tags:
   - changelogs
   - 1.17
+major_minor: 1.17
 version: 1.17.9
 ---
 

--- a/content/en/changelogs/1.18.0-changelog.md
+++ b/content/en/changelogs/1.18.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.0
+title: Spinnaker Release 1.18.0
 date: 2020-01-22 13:18:57 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18
 version: 1.18.0
 ---
 

--- a/content/en/changelogs/1.18.0-changelog.md
+++ b/content/en/changelogs/1.18.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.0
 date: 2020-01-22 13:18:57 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18
 version: 1.18.0
 ---

--- a/content/en/changelogs/1.18.1-changelog.md
+++ b/content/en/changelogs/1.18.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.1
 date: 2020-01-31 19:10:30 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18
 version: 1.18.1
 ---

--- a/content/en/changelogs/1.18.1-changelog.md
+++ b/content/en/changelogs/1.18.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.1
+title: Spinnaker Release 1.18.1
 date: 2020-01-31 19:10:30 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18
 version: 1.18.1
 ---
 

--- a/content/en/changelogs/1.18.10-changelog.md
+++ b/content/en/changelogs/1.18.10-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.10
 date: 2020-05-05 13:46:33 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18.10-changelog.md
 version: 1.18.10
 ---

--- a/content/en/changelogs/1.18.10-changelog.md
+++ b/content/en/changelogs/1.18.10-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.10
+title: Spinnaker Release 1.18.10
 date: 2020-05-05 13:46:33 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18.10-changelog.md
 version: 1.18.10
 ---
 

--- a/content/en/changelogs/1.18.11-changelog.md
+++ b/content/en/changelogs/1.18.11-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.11
 date: 2020-05-11 13:10:33 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18.11-changelog.md
 version: 1.18.11
 ---

--- a/content/en/changelogs/1.18.11-changelog.md
+++ b/content/en/changelogs/1.18.11-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.11
+title: Spinnaker Release 1.18.11
 date: 2020-05-11 13:10:33 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18.11-changelog.md
 version: 1.18.11
 ---
 

--- a/content/en/changelogs/1.18.12-changelog.md
+++ b/content/en/changelogs/1.18.12-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.12
 date: 2020-05-26 13:00:37 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18.12-changelog.md
 version: 1.18.12
 ---

--- a/content/en/changelogs/1.18.12-changelog.md
+++ b/content/en/changelogs/1.18.12-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.12
+title: Spinnaker Release 1.18.12
 date: 2020-05-26 13:00:37 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18.12-changelog.md
 version: 1.18.12
 ---
 

--- a/content/en/changelogs/1.18.2-changelog.md
+++ b/content/en/changelogs/1.18.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.2
+title: Spinnaker Release 1.18.2
 date: 2020-02-10 14:31:18 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18
 version: 1.18.2
 ---
 

--- a/content/en/changelogs/1.18.2-changelog.md
+++ b/content/en/changelogs/1.18.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.2
 date: 2020-02-10 14:31:18 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18
 version: 1.18.2
 ---

--- a/content/en/changelogs/1.18.3-changelog.md
+++ b/content/en/changelogs/1.18.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.3
 date: 2020-02-20 18:36:42 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18
 version: 1.18.3
 ---

--- a/content/en/changelogs/1.18.3-changelog.md
+++ b/content/en/changelogs/1.18.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.3
+title: Spinnaker Release 1.18.3
 date: 2020-02-20 18:36:42 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18
 version: 1.18.3
 ---
 

--- a/content/en/changelogs/1.18.4-changelog.md
+++ b/content/en/changelogs/1.18.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.4
 date: 2020-02-27 21:59:13 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18
 version: 1.18.4
 ---

--- a/content/en/changelogs/1.18.4-changelog.md
+++ b/content/en/changelogs/1.18.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.4
+title: Spinnaker Release 1.18.4
 date: 2020-02-27 21:59:13 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18
 version: 1.18.4
 ---
 

--- a/content/en/changelogs/1.18.5-changelog.md
+++ b/content/en/changelogs/1.18.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.5
 date: 2020-03-09 19:44:10 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18
 version: 1.18.5
 ---

--- a/content/en/changelogs/1.18.5-changelog.md
+++ b/content/en/changelogs/1.18.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.5
+title: Spinnaker Release 1.18.5
 date: 2020-03-09 19:44:10 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18
 version: 1.18.5
 ---
 

--- a/content/en/changelogs/1.18.6-changelog.md
+++ b/content/en/changelogs/1.18.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.6
 date: 2020-03-16 21:58:05 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18
 version: 1.18.6
 ---

--- a/content/en/changelogs/1.18.6-changelog.md
+++ b/content/en/changelogs/1.18.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.6
+title: Spinnaker Release 1.18.6
 date: 2020-03-16 21:58:05 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18
 version: 1.18.6
 ---
 

--- a/content/en/changelogs/1.18.7-changelog.md
+++ b/content/en/changelogs/1.18.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.7
+title: Spinnaker Release 1.18.7
 date: 2020-03-30 22:44:12 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18
 version: 1.18.7
 ---
 

--- a/content/en/changelogs/1.18.7-changelog.md
+++ b/content/en/changelogs/1.18.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.7
 date: 2020-03-30 22:44:12 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18
 version: 1.18.7
 ---

--- a/content/en/changelogs/1.18.8-changelog.md
+++ b/content/en/changelogs/1.18.8-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.8
 date: 2020-04-03 18:55:22 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18
 version: 1.18.8
 ---

--- a/content/en/changelogs/1.18.8-changelog.md
+++ b/content/en/changelogs/1.18.8-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.8
+title: Spinnaker Release 1.18.8
 date: 2020-04-03 18:55:22 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18
 version: 1.18.8
 ---
 

--- a/content/en/changelogs/1.18.9-changelog.md
+++ b/content/en/changelogs/1.18.9-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.18
-changelog_title: Version 1.18.9
+title: Spinnaker Release 1.18.9
 date: 2020-04-15 18:01:42 +0000
 tags:
   - changelogs
   - 1.18
+major_minor: 1.18
 version: 1.18.9
 ---
 

--- a/content/en/changelogs/1.18.9-changelog.md
+++ b/content/en/changelogs/1.18.9-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.18.9
 date: 2020-04-15 18:01:42 +0000
-tags:
-  - changelogs
-  - 1.18
 major_minor: 1.18
 version: 1.18.9
 ---

--- a/content/en/changelogs/1.19.0-changelog.md
+++ b/content/en/changelogs/1.19.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.0
 date: 2020-03-11 20:23:08 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19
 version: 1.19.0
 ---

--- a/content/en/changelogs/1.19.0-changelog.md
+++ b/content/en/changelogs/1.19.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.0
+title: Spinnaker Release 1.19.0
 date: 2020-03-11 20:23:08 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19
 version: 1.19.0
 ---
 

--- a/content/en/changelogs/1.19.1-changelog.md
+++ b/content/en/changelogs/1.19.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.1
 date: 2020-03-16 21:54:51 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19
 version: 1.19.1
 ---

--- a/content/en/changelogs/1.19.1-changelog.md
+++ b/content/en/changelogs/1.19.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.1
+title: Spinnaker Release 1.19.1
 date: 2020-03-16 21:54:51 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19
 version: 1.19.1
 ---
 

--- a/content/en/changelogs/1.19.10-changelog.md
+++ b/content/en/changelogs/1.19.10-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.10
 date: 2020-05-26 13:04:08 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19.10-changelog.md
 version: 1.19.10
 ---

--- a/content/en/changelogs/1.19.10-changelog.md
+++ b/content/en/changelogs/1.19.10-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.10
+title: Spinnaker Release 1.19.10
 date: 2020-05-26 13:04:08 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19.10-changelog.md
 version: 1.19.10
 ---
 

--- a/content/en/changelogs/1.19.11-changelog.md
+++ b/content/en/changelogs/1.19.11-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.11
+title: Spinnaker Release 1.19.11
 date: 2020-06-01 14:38:23 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19.11-changelog.md
 version: 1.19.11
 ---
 

--- a/content/en/changelogs/1.19.11-changelog.md
+++ b/content/en/changelogs/1.19.11-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.11
 date: 2020-06-01 14:38:23 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19.11-changelog.md
 version: 1.19.11
 ---

--- a/content/en/changelogs/1.19.12-changelog.md
+++ b/content/en/changelogs/1.19.12-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.12
 date: 2020-06-30 20:38:40 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19.12-changelog.md
 version: 1.19.12
 ---

--- a/content/en/changelogs/1.19.12-changelog.md
+++ b/content/en/changelogs/1.19.12-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.12
+title: Spinnaker Release 1.19.12
 date: 2020-06-30 20:38:40 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19.12-changelog.md
 version: 1.19.12
 ---
 

--- a/content/en/changelogs/1.19.13-changelog.md
+++ b/content/en/changelogs/1.19.13-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.13
 date: 2020-07-28 01:22:03 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19.13-changelog.md
 version: 1.19.13
 ---

--- a/content/en/changelogs/1.19.13-changelog.md
+++ b/content/en/changelogs/1.19.13-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.13
+title: Spinnaker Release 1.19.13
 date: 2020-07-28 01:22:03 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19.13-changelog.md
 version: 1.19.13
 ---
 

--- a/content/en/changelogs/1.19.14-changelog.md
+++ b/content/en/changelogs/1.19.14-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.14
 date: 2020-08-13 23:44:46 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19.14-changelog.md
 version: 1.19.14
 ---

--- a/content/en/changelogs/1.19.14-changelog.md
+++ b/content/en/changelogs/1.19.14-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.14
+title: Spinnaker Release 1.19.14
 date: 2020-08-13 23:44:46 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19.14-changelog.md
 version: 1.19.14
 ---
 

--- a/content/en/changelogs/1.19.2-changelog.md
+++ b/content/en/changelogs/1.19.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.2
 date: 2020-03-20 21:17:01 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19
 version: 1.19.2
 ---

--- a/content/en/changelogs/1.19.2-changelog.md
+++ b/content/en/changelogs/1.19.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.2
+title: Spinnaker Release 1.19.2
 date: 2020-03-20 21:17:01 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19
 version: 1.19.2
 ---
 

--- a/content/en/changelogs/1.19.3-changelog.md
+++ b/content/en/changelogs/1.19.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.3
+title: Spinnaker Release 1.19.3
 date: 2020-03-30 23:00:57 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19
 version: 1.19.3
 ---
 

--- a/content/en/changelogs/1.19.3-changelog.md
+++ b/content/en/changelogs/1.19.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.3
 date: 2020-03-30 23:00:57 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19
 version: 1.19.3
 ---

--- a/content/en/changelogs/1.19.4-changelog.md
+++ b/content/en/changelogs/1.19.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.4
 date: 2020-04-03 18:58:22 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19
 version: 1.19.4
 ---

--- a/content/en/changelogs/1.19.4-changelog.md
+++ b/content/en/changelogs/1.19.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.4
+title: Spinnaker Release 1.19.4
 date: 2020-04-03 18:58:22 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19
 version: 1.19.4
 ---
 

--- a/content/en/changelogs/1.19.5-changelog.md
+++ b/content/en/changelogs/1.19.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.5
 date: 2020-04-15 18:04:36 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19
 version: 1.19.5
 ---

--- a/content/en/changelogs/1.19.5-changelog.md
+++ b/content/en/changelogs/1.19.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.5
+title: Spinnaker Release 1.19.5
 date: 2020-04-15 18:04:36 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19
 version: 1.19.5
 ---
 

--- a/content/en/changelogs/1.19.6-changelog.md
+++ b/content/en/changelogs/1.19.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.6
+title: Spinnaker Release 1.19.6
 date: 2020-04-23 15:53:53 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19
 version: 1.19.6
 ---
 

--- a/content/en/changelogs/1.19.6-changelog.md
+++ b/content/en/changelogs/1.19.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.6
 date: 2020-04-23 15:53:53 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19
 version: 1.19.6
 ---

--- a/content/en/changelogs/1.19.7-changelog.md
+++ b/content/en/changelogs/1.19.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.7
 date: 2020-05-05 11:53:08 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19
 version: 1.19.7
 ---

--- a/content/en/changelogs/1.19.7-changelog.md
+++ b/content/en/changelogs/1.19.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.7
+title: Spinnaker Release 1.19.7
 date: 2020-05-05 11:53:08 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19
 version: 1.19.7
 ---
 

--- a/content/en/changelogs/1.19.8-changelog.md
+++ b/content/en/changelogs/1.19.8-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.8
 date: 2020-05-11 13:15:12 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19
 version: 1.19.8
 ---

--- a/content/en/changelogs/1.19.8-changelog.md
+++ b/content/en/changelogs/1.19.8-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.8
+title: Spinnaker Release 1.19.8
 date: 2020-05-11 13:15:12 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19
 version: 1.19.8
 ---
 

--- a/content/en/changelogs/1.19.9-changelog.md
+++ b/content/en/changelogs/1.19.9-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.19.9
 date: 2020-05-19 13:43:05 +0000
-tags:
-  - changelogs
-  - 1.19
 major_minor: 1.19
 version: 1.19.9
 ---

--- a/content/en/changelogs/1.19.9-changelog.md
+++ b/content/en/changelogs/1.19.9-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.19
-changelog_title: Version 1.19.9
+title: Spinnaker Release 1.19.9
 date: 2020-05-19 13:43:05 +0000
 tags:
   - changelogs
   - 1.19
+major_minor: 1.19
 version: 1.19.9
 ---
 

--- a/content/en/changelogs/1.2.1-changelog.md
+++ b/content/en/changelogs/1.2.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.2.1
 date: 2017-08-09 20:09:52
-tags:
-  - changelogs
-  - 1.2
 major_minor: 1.2
 version: 1.2.1
 ---

--- a/content/en/changelogs/1.2.1-changelog.md
+++ b/content/en/changelogs/1.2.1-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.2
-changelog_title: Version 1.2.1
+title: Spinnaker Release 1.2.1
 date: 2017-08-09 20:09:52
 tags:
   - changelogs
   - 1.2
+major_minor: 1.2
+version: 1.2.1
 ---
 
 <script src="https://gist.github.com/spinnaker-release/512f9f19181c4c19b5d614c44aa9bcaf.js"></script>

--- a/content/en/changelogs/1.2.2-changelog.md
+++ b/content/en/changelogs/1.2.2-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.2
-changelog_title: Version 1.2.2
+title: Spinnaker Release 1.2.2
 date: 2017-08-22 11:55:01
 tags:
   - changelogs
   - 1.2
+major_minor: 1.2
+version: 1.2.2
 ---
 
 <script src="https://gist.github.com/spinnaker-release/84b75e3701652dfedb86e20b806cbc39.js"></script>

--- a/content/en/changelogs/1.2.2-changelog.md
+++ b/content/en/changelogs/1.2.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.2.2
 date: 2017-08-22 11:55:01
-tags:
-  - changelogs
-  - 1.2
 major_minor: 1.2
 version: 1.2.2
 ---

--- a/content/en/changelogs/1.20.0-changelog.md
+++ b/content/en/changelogs/1.20.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.20
-changelog_title: Version 1.20.0
+title: Spinnaker Release 1.20.0
 date: 2020-05-04 17:59:33 +0000
 tags:
   - changelogs
   - 1.20
+major_minor: 1.20
 version: 1.20.0
 ---
 

--- a/content/en/changelogs/1.20.0-changelog.md
+++ b/content/en/changelogs/1.20.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.20.0
 date: 2020-05-04 17:59:33 +0000
-tags:
-  - changelogs
-  - 1.20
 major_minor: 1.20
 version: 1.20.0
 ---

--- a/content/en/changelogs/1.20.1-changelog.md
+++ b/content/en/changelogs/1.20.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.20.1
 date: 2020-05-11 13:19:23 +0000
-tags:
-  - changelogs
-  - 1.20
 major_minor: 1.20
 version: 1.20.1
 ---

--- a/content/en/changelogs/1.20.1-changelog.md
+++ b/content/en/changelogs/1.20.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.20
-changelog_title: Version 1.20.1
+title: Spinnaker Release 1.20.1
 date: 2020-05-11 13:19:23 +0000
 tags:
   - changelogs
   - 1.20
+major_minor: 1.20
 version: 1.20.1
 ---
 

--- a/content/en/changelogs/1.20.2-changelog.md
+++ b/content/en/changelogs/1.20.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.20.2
 date: 2020-05-18 14:29:08 +0000
-tags:
-  - changelogs
-  - 1.20
 major_minor: 1.20
 version: 1.20.2
 ---

--- a/content/en/changelogs/1.20.2-changelog.md
+++ b/content/en/changelogs/1.20.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.20
-changelog_title: Version 1.20.2
+title: Spinnaker Release 1.20.2
 date: 2020-05-18 14:29:08 +0000
 tags:
   - changelogs
   - 1.20
+major_minor: 1.20
 version: 1.20.2
 ---
 

--- a/content/en/changelogs/1.20.3-changelog.md
+++ b/content/en/changelogs/1.20.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.20.3
 date: 2020-05-26 15:33:27 +0000
-tags:
-  - changelogs
-  - 1.20
 major_minor: 1.20
 version: 1.20.3
 ---

--- a/content/en/changelogs/1.20.3-changelog.md
+++ b/content/en/changelogs/1.20.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.20
-changelog_title: Version 1.20.3
+title: Spinnaker Release 1.20.3
 date: 2020-05-26 15:33:27 +0000
 tags:
   - changelogs
   - 1.20
+major_minor: 1.20
 version: 1.20.3
 ---
 

--- a/content/en/changelogs/1.20.4-changelog.md
+++ b/content/en/changelogs/1.20.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.20
-changelog_title: Version 1.20.4
+title: Spinnaker Release 1.20.4
 date: 2020-06-01 16:56:02 +0000
 tags:
   - changelogs
   - 1.20
+major_minor: 1.20
 version: 1.20.4
 ---
 

--- a/content/en/changelogs/1.20.4-changelog.md
+++ b/content/en/changelogs/1.20.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.20.4
 date: 2020-06-01 16:56:02 +0000
-tags:
-  - changelogs
-  - 1.20
 major_minor: 1.20
 version: 1.20.4
 ---

--- a/content/en/changelogs/1.20.5-changelog.md
+++ b/content/en/changelogs/1.20.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.20.5
 date: 2020-06-08 15:10:44 +0000
-tags:
-  - changelogs
-  - 1.20
 major_minor: 1.20
 version: 1.20.5
 ---

--- a/content/en/changelogs/1.20.5-changelog.md
+++ b/content/en/changelogs/1.20.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.20
-changelog_title: Version 1.20.5
+title: Spinnaker Release 1.20.5
 date: 2020-06-08 15:10:44 +0000
 tags:
   - changelogs
   - 1.20
+major_minor: 1.20
 version: 1.20.5
 ---
 

--- a/content/en/changelogs/1.20.6-changelog.md
+++ b/content/en/changelogs/1.20.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.20.6
 date: 2020-06-25 17:12:29 +0000
-tags:
-  - changelogs
-  - 1.20
 major_minor: 1.20
 version: 1.20.6
 ---

--- a/content/en/changelogs/1.20.6-changelog.md
+++ b/content/en/changelogs/1.20.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.20
-changelog_title: Version 1.20.6
+title: Spinnaker Release 1.20.6
 date: 2020-06-25 17:12:29 +0000
 tags:
   - changelogs
   - 1.20
+major_minor: 1.20
 version: 1.20.6
 ---
 

--- a/content/en/changelogs/1.20.7-changelog.md
+++ b/content/en/changelogs/1.20.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.20
-changelog_title: Version 1.20.7
+title: Spinnaker Release 1.20.7
 date: 2020-07-22 22:22:44 +0000
 tags:
   - changelogs
   - 1.20
+major_minor: 1.20
 version: 1.20.7
 ---
 

--- a/content/en/changelogs/1.20.7-changelog.md
+++ b/content/en/changelogs/1.20.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.20.7
 date: 2020-07-22 22:22:44 +0000
-tags:
-  - changelogs
-  - 1.20
 major_minor: 1.20
 version: 1.20.7
 ---

--- a/content/en/changelogs/1.20.8-changelog.md
+++ b/content/en/changelogs/1.20.8-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.20
-changelog_title: Version 1.20.8
+title: Spinnaker Release 1.20.8
 date: 2020-08-13 00:20:30 +0000
 tags:
   - changelogs
   - 1.20
+major_minor: 1.20
 version: 1.20.8
 ---
 

--- a/content/en/changelogs/1.20.8-changelog.md
+++ b/content/en/changelogs/1.20.8-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.20.8
 date: 2020-08-13 00:20:30 +0000
-tags:
-  - changelogs
-  - 1.20
 major_minor: 1.20
 version: 1.20.8
 ---

--- a/content/en/changelogs/1.21.0-changelog.md
+++ b/content/en/changelogs/1.21.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.21
-changelog_title: Version 1.21.0
+title: Spinnaker Release 1.21.0
 date: 2020-06-29 18:46:10 +0000
 tags:
   - changelogs
   - 1.21
+major_minor: 1.21
 version: 1.21.0
 ---
 

--- a/content/en/changelogs/1.21.0-changelog.md
+++ b/content/en/changelogs/1.21.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.21.0
 date: 2020-06-29 18:46:10 +0000
-tags:
-  - changelogs
-  - 1.21
 major_minor: 1.21
 version: 1.21.0
 ---

--- a/content/en/changelogs/1.21.1-changelog.md
+++ b/content/en/changelogs/1.21.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.21
-changelog_title: Version 1.21.1
+title: Spinnaker Release 1.21.1
 date: 2020-07-22 17:46:16 +0000
 tags:
   - changelogs
   - 1.21
+major_minor: 1.21
 version: 1.21.1
 ---
 

--- a/content/en/changelogs/1.21.1-changelog.md
+++ b/content/en/changelogs/1.21.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.21.1
 date: 2020-07-22 17:46:16 +0000
-tags:
-  - changelogs
-  - 1.21
 major_minor: 1.21
 version: 1.21.1
 ---

--- a/content/en/changelogs/1.21.2-changelog.md
+++ b/content/en/changelogs/1.21.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.21
-changelog_title: Version 1.21.2
+title: Spinnaker Release 1.21.2
 date: 2020-07-24 02:06:47 +0000
 tags:
   - changelogs
   - 1.21
+major_minor: 1.21
 version: 1.21.2
 ---
 

--- a/content/en/changelogs/1.21.2-changelog.md
+++ b/content/en/changelogs/1.21.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.21.2
 date: 2020-07-24 02:06:47 +0000
-tags:
-  - changelogs
-  - 1.21
 major_minor: 1.21
 version: 1.21.2
 ---

--- a/content/en/changelogs/1.21.3-changelog.md
+++ b/content/en/changelogs/1.21.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.21.3
 date: 2020-08-08 00:08:18 +0000
-tags:
-  - changelogs
-  - 1.21
 major_minor: 1.21
 version: 1.21.3
 ---

--- a/content/en/changelogs/1.21.3-changelog.md
+++ b/content/en/changelogs/1.21.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.21
-changelog_title: Version 1.21.3
+title: Spinnaker Release 1.21.3
 date: 2020-08-08 00:08:18 +0000
 tags:
   - changelogs
   - 1.21
+major_minor: 1.21
 version: 1.21.3
 ---
 

--- a/content/en/changelogs/1.21.4-changelog.md
+++ b/content/en/changelogs/1.21.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.21.4
 date: 2020-08-13 00:23:38 +0000
-tags:
-  - changelogs
-  - 1.21
 major_minor: 1.21
 version: 1.21.4
 ---

--- a/content/en/changelogs/1.21.4-changelog.md
+++ b/content/en/changelogs/1.21.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.21
-changelog_title: Version 1.21.4
+title: Spinnaker Release 1.21.4
 date: 2020-08-13 00:23:38 +0000
 tags:
   - changelogs
   - 1.21
+major_minor: 1.21
 version: 1.21.4
 ---
 

--- a/content/en/changelogs/1.21.5-changelog.md
+++ b/content/en/changelogs/1.21.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.21
-changelog_title: Version 1.21.5
+title: Spinnaker Release 1.21.5
 date: 2020-12-07 23:09:05 +0000
 tags:
   - changelogs
   - 1.21
+major_minor: 1.21
 version: 1.21.5
 ---
 

--- a/content/en/changelogs/1.21.5-changelog.md
+++ b/content/en/changelogs/1.21.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.21.5
 date: 2020-12-07 23:09:05 +0000
-tags:
-  - changelogs
-  - 1.21
 major_minor: 1.21
 version: 1.21.5
 ---

--- a/content/en/changelogs/1.22.0-changelog.md
+++ b/content/en/changelogs/1.22.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.22
-changelog_title: Version 1.22.0
+title: Spinnaker Release 1.22.0
 date: 2020-08-24 16:10:02 +0000
 tags:
   - changelogs
   - 1.22
+major_minor: 1.22
 version: 1.22.0
 ---
 

--- a/content/en/changelogs/1.22.0-changelog.md
+++ b/content/en/changelogs/1.22.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.22.0
 date: 2020-08-24 16:10:02 +0000
-tags:
-  - changelogs
-  - 1.22
 major_minor: 1.22
 version: 1.22.0
 ---

--- a/content/en/changelogs/1.22.1-changelog.md
+++ b/content/en/changelogs/1.22.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.22.1
 date: 2020-08-31 14:48:37 +0000
-tags:
-  - changelogs
-  - 1.22
 major_minor: 1.22
 version: 1.22.1
 ---

--- a/content/en/changelogs/1.22.1-changelog.md
+++ b/content/en/changelogs/1.22.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.22
-changelog_title: Version 1.22.1
+title: Spinnaker Release 1.22.1
 date: 2020-08-31 14:48:37 +0000
 tags:
   - changelogs
   - 1.22
+major_minor: 1.22
 version: 1.22.1
 ---
 

--- a/content/en/changelogs/1.22.2-changelog.md
+++ b/content/en/changelogs/1.22.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.22
-changelog_title: Version 1.22.2
+title: Spinnaker Release 1.22.2
 date: 2020-10-13 15:18:00 +0000
 tags:
   - changelogs
   - 1.22
+major_minor: 1.22
 version: 1.22.2
 ---
 

--- a/content/en/changelogs/1.22.2-changelog.md
+++ b/content/en/changelogs/1.22.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.22.2
 date: 2020-10-13 15:18:00 +0000
-tags:
-  - changelogs
-  - 1.22
 major_minor: 1.22
 version: 1.22.2
 ---

--- a/content/en/changelogs/1.22.3-changelog.md
+++ b/content/en/changelogs/1.22.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.22
-changelog_title: Version 1.22.3
+title: Spinnaker Release 1.22.3
 date: 2020-12-01 17:26:40 +0000
 tags:
   - changelogs
   - 1.22
+major_minor: 1.22
 version: 1.22.3
 ---
 

--- a/content/en/changelogs/1.22.3-changelog.md
+++ b/content/en/changelogs/1.22.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.22.3
 date: 2020-12-01 17:26:40 +0000
-tags:
-  - changelogs
-  - 1.22
 major_minor: 1.22
 version: 1.22.3
 ---

--- a/content/en/changelogs/1.22.4-changelog.md
+++ b/content/en/changelogs/1.22.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.22.4
 date: 2020-12-08 14:56:16 +0000
-tags:
-  - changelogs
-  - 1.22
 major_minor: 1.22
 version: 1.22.4
 ---

--- a/content/en/changelogs/1.22.4-changelog.md
+++ b/content/en/changelogs/1.22.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.22
-changelog_title: Version 1.22.4
+title: Spinnaker Release 1.22.4
 date: 2020-12-08 14:56:16 +0000
 tags:
   - changelogs
   - 1.22
+major_minor: 1.22
 version: 1.22.4
 ---
 

--- a/content/en/changelogs/1.22.5-changelog.md
+++ b/content/en/changelogs/1.22.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.22.5
 date: 2021-01-26 23:06:26 +0000
-tags:
-  - changelogs
-  - 1.22
 major_minor: 1.22
 version: 1.22.5
 type: changelog

--- a/content/en/changelogs/1.22.5-changelog.md
+++ b/content/en/changelogs/1.22.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.22
-changelog_title: Version 1.22.5
+title: Spinnaker Release 1.22.5
 date: 2021-01-26 23:06:26 +0000
 tags:
   - changelogs
   - 1.22
+major_minor: 1.22
 version: 1.22.5
 type: changelog
 ---

--- a/content/en/changelogs/1.22.6-changelog.md
+++ b/content/en/changelogs/1.22.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.22.6
 date: 2021-01-28 02:11:57 +0000
-tags:
-  - changelogs
-  - 1.22
 major_minor: 1.22
 version: 1.22.6
 ---

--- a/content/en/changelogs/1.22.6-changelog.md
+++ b/content/en/changelogs/1.22.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.22
-changelog_title: Version 1.22.6
+title: Spinnaker Release 1.22.6
 date: 2021-01-28 02:11:57 +0000
 tags:
   - changelogs
   - 1.22
+major_minor: 1.22
 version: 1.22.6
 ---
 

--- a/content/en/changelogs/1.23.0-changelog.md
+++ b/content/en/changelogs/1.23.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.23
-changelog_title: Version 1.23.0
+title: Spinnaker Release 1.23.0
 date: 2020-10-20 16:38:34 +0000
 tags:
   - changelogs
   - 1.23
+major_minor: 1.23
 version: 1.23.0
 ---
 

--- a/content/en/changelogs/1.23.0-changelog.md
+++ b/content/en/changelogs/1.23.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.23.0
 date: 2020-10-20 16:38:34 +0000
-tags:
-  - changelogs
-  - 1.23
 major_minor: 1.23
 version: 1.23.0
 ---

--- a/content/en/changelogs/1.23.1-changelog.md
+++ b/content/en/changelogs/1.23.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.23
-changelog_title: Version 1.23.1
+title: Spinnaker Release 1.23.1
 date: 2020-11-03 14:34:07 +0000
 tags:
   - changelogs
   - 1.23
+major_minor: 1.23
 version: 1.23.1
 ---
 

--- a/content/en/changelogs/1.23.1-changelog.md
+++ b/content/en/changelogs/1.23.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.23.1
 date: 2020-11-03 14:34:07 +0000
-tags:
-  - changelogs
-  - 1.23
 major_minor: 1.23
 version: 1.23.1
 ---

--- a/content/en/changelogs/1.23.2-changelog.md
+++ b/content/en/changelogs/1.23.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.23
-changelog_title: Version 1.23.2
+title: Spinnaker Release 1.23.2
 date: 2020-11-16 17:26:41 +0000
 tags:
   - changelogs
   - 1.23
+major_minor: 1.23
 version: 1.23.2
 ---
 

--- a/content/en/changelogs/1.23.2-changelog.md
+++ b/content/en/changelogs/1.23.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.23.2
 date: 2020-11-16 17:26:41 +0000
-tags:
-  - changelogs
-  - 1.23
 major_minor: 1.23
 version: 1.23.2
 ---

--- a/content/en/changelogs/1.23.3-changelog.md
+++ b/content/en/changelogs/1.23.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.23.3
 date: 2020-12-01 18:37:53 +0000
-tags:
-  - changelogs
-  - 1.23
 major_minor: 1.23
 version: 1.23.3
 ---

--- a/content/en/changelogs/1.23.3-changelog.md
+++ b/content/en/changelogs/1.23.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.23
-changelog_title: Version 1.23.3
+title: Spinnaker Release 1.23.3
 date: 2020-12-01 18:37:53 +0000
 tags:
   - changelogs
   - 1.23
+major_minor: 1.23
 version: 1.23.3
 ---
 

--- a/content/en/changelogs/1.23.4-changelog.md
+++ b/content/en/changelogs/1.23.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.23
-changelog_title: Version 1.23.4
+title: Spinnaker Release 1.23.4
 date: 2020-12-08 16:31:32 +0000
 tags:
   - changelogs
   - 1.23
+major_minor: 1.23
 version: 1.23.4
 ---
 

--- a/content/en/changelogs/1.23.4-changelog.md
+++ b/content/en/changelogs/1.23.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.23.4
 date: 2020-12-08 16:31:32 +0000
-tags:
-  - changelogs
-  - 1.23
 major_minor: 1.23
 version: 1.23.4
 ---

--- a/content/en/changelogs/1.23.5-changelog.md
+++ b/content/en/changelogs/1.23.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.23
-changelog_title: Version 1.23.5
+title: Spinnaker Release 1.23.5
 date: 2020-12-14 19:08:41 +0000
 tags:
   - changelogs
   - 1.23
+major_minor: 1.23
 version: 1.23.5
 ---
 

--- a/content/en/changelogs/1.23.5-changelog.md
+++ b/content/en/changelogs/1.23.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.23.5
 date: 2020-12-14 19:08:41 +0000
-tags:
-  - changelogs
-  - 1.23
 major_minor: 1.23
 version: 1.23.5
 ---

--- a/content/en/changelogs/1.23.6-changelog.md
+++ b/content/en/changelogs/1.23.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.23
-changelog_title: Version 1.23.6
+title: Spinnaker Release 1.23.6
 date: 2021-01-28 14:39:41 +0000
 tags:
   - changelogs
   - 1.23
+major_minor: 1.23
 version: 1.23.6
 ---
 

--- a/content/en/changelogs/1.23.6-changelog.md
+++ b/content/en/changelogs/1.23.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.23.6
 date: 2021-01-28 14:39:41 +0000
-tags:
-  - changelogs
-  - 1.23
 major_minor: 1.23
 version: 1.23.6
 ---

--- a/content/en/changelogs/1.23.7-changelog.md
+++ b/content/en/changelogs/1.23.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.23.7
 date: 2021-02-19 01:25:30 +0000
-tags:
-  - changelogs
-  - 1.23
 major_minor: 1.23
 version: 1.23.7
 ---

--- a/content/en/changelogs/1.23.7-changelog.md
+++ b/content/en/changelogs/1.23.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.23
-changelog_title: Version 1.23.7
+title: Spinnaker Release 1.23.7
 date: 2021-02-19 01:25:30 +0000
 tags:
   - changelogs
   - 1.23
+major_minor: 1.23
 version: 1.23.7
 ---
 

--- a/content/en/changelogs/1.24.0-changelog.md
+++ b/content/en/changelogs/1.24.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.24.0
 date: 2020-12-14 20:34:17 +0000
-tags:
-  - changelogs
-  - 1.24
 major_minor: 1.24
 version: 1.24.0
 ---

--- a/content/en/changelogs/1.24.0-changelog.md
+++ b/content/en/changelogs/1.24.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.24
-changelog_title: Version 1.24.0
+title: Spinnaker Release 1.24.0
 date: 2020-12-14 20:34:17 +0000
 tags:
   - changelogs
   - 1.24
+major_minor: 1.24
 version: 1.24.0
 ---
 

--- a/content/en/changelogs/1.24.1-changelog.md
+++ b/content/en/changelogs/1.24.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.24
-changelog_title: Version 1.24.1
+title: Spinnaker Release 1.24.1
 date: 2020-12-21 23:36:25 +0000
 tags:
   - changelogs
   - 1.24
+major_minor: 1.24
 version: 1.24.1
 ---
 

--- a/content/en/changelogs/1.24.1-changelog.md
+++ b/content/en/changelogs/1.24.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.24.1
 date: 2020-12-21 23:36:25 +0000
-tags:
-  - changelogs
-  - 1.24
 major_minor: 1.24
 version: 1.24.1
 ---

--- a/content/en/changelogs/1.24.2-changelog.md
+++ b/content/en/changelogs/1.24.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.24
-changelog_title: Version 1.24.2
+title: Spinnaker Release 1.24.2
 date: 2021-01-06 18:32:52 +0000
 tags:
   - changelogs
   - 1.24
+major_minor: 1.24
 version: 1.24.2
 ---
 

--- a/content/en/changelogs/1.24.2-changelog.md
+++ b/content/en/changelogs/1.24.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.24.2
 date: 2021-01-06 18:32:52 +0000
-tags:
-  - changelogs
-  - 1.24
 major_minor: 1.24
 version: 1.24.2
 ---

--- a/content/en/changelogs/1.24.3-changelog.md
+++ b/content/en/changelogs/1.24.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.24
-changelog_title: Version 1.24.3
+title: Spinnaker Release 1.24.3
 date: 2021-01-27 15:40:26 +0000
 tags:
   - changelogs
   - 1.24
+major_minor: 1.24
 version: 1.24.3
 ---
 

--- a/content/en/changelogs/1.24.3-changelog.md
+++ b/content/en/changelogs/1.24.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.24.3
 date: 2021-01-27 15:40:26 +0000
-tags:
-  - changelogs
-  - 1.24
 major_minor: 1.24
 version: 1.24.3
 ---

--- a/content/en/changelogs/1.24.4-changelog.md
+++ b/content/en/changelogs/1.24.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.24
-changelog_title: Version 1.24.4
+title: Spinnaker Release 1.24.4
 date: 2021-02-03 23:13:08 +0000
 tags:
   - changelogs
   - 1.24
+major_minor: 1.24
 version: 1.24.4
 ---
 

--- a/content/en/changelogs/1.24.4-changelog.md
+++ b/content/en/changelogs/1.24.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.24.4
 date: 2021-02-03 23:13:08 +0000
-tags:
-  - changelogs
-  - 1.24
 major_minor: 1.24
 version: 1.24.4
 ---

--- a/content/en/changelogs/1.24.5-changelog.md
+++ b/content/en/changelogs/1.24.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.24.5
 date: 2021-05-27 08:56:51 +0000
-tags:
-  - changelogs
-  - 1.24
 major_minor: 1.24
 version: 1.24.5
 ---

--- a/content/en/changelogs/1.24.5-changelog.md
+++ b/content/en/changelogs/1.24.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.24
-changelog_title: Version 1.24.5
+title: Spinnaker Release 1.24.5
 date: 2021-05-27 08:56:51 +0000
 tags:
   - changelogs
   - 1.24
+major_minor: 1.24
 version: 1.24.5
 ---
 

--- a/content/en/changelogs/1.24.6-changelog.md
+++ b/content/en/changelogs/1.24.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.24.6
 date: 2021-07-01 20:40:34 +0000
-tags:
-  - changelogs
-  - 1.24
 major_minor: 1.24
 version: 1.24.6
 ---

--- a/content/en/changelogs/1.24.6-changelog.md
+++ b/content/en/changelogs/1.24.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.24
-changelog_title: Version 1.24.6
+title: Spinnaker Release 1.24.6
 date: 2021-07-01 20:40:34 +0000
 tags:
   - changelogs
   - 1.24
+major_minor: 1.24
 version: 1.24.6
 ---
 

--- a/content/en/changelogs/1.25.0-changelog.md
+++ b/content/en/changelogs/1.25.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.25.0
 date: 2021-02-23 22:05:06 +0000
-tags:
-  - changelogs
-  - 1.25
 major_minor: 1.25
 version: 1.25.0
 ---

--- a/content/en/changelogs/1.25.0-changelog.md
+++ b/content/en/changelogs/1.25.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.25
-changelog_title: Version 1.25.0
+title: Spinnaker Release 1.25.0
 date: 2021-02-23 22:05:06 +0000
 tags:
   - changelogs
   - 1.25
+major_minor: 1.25
 version: 1.25.0
 ---
 

--- a/content/en/changelogs/1.25.1-changelog.md
+++ b/content/en/changelogs/1.25.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.25
-changelog_title: Version 1.25.1
+title: Spinnaker Release 1.25.1
 date: 2021-03-03 08:29:00 +0000
 tags:
   - changelogs
   - 1.25
+major_minor: 1.25
 version: 1.25.1
 ---
 

--- a/content/en/changelogs/1.25.1-changelog.md
+++ b/content/en/changelogs/1.25.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.25.1
 date: 2021-03-03 08:29:00 +0000
-tags:
-  - changelogs
-  - 1.25
 major_minor: 1.25
 version: 1.25.1
 ---

--- a/content/en/changelogs/1.25.2-changelog.md
+++ b/content/en/changelogs/1.25.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.25.2
 date: 2021-03-09 07:57:50 +0000
-tags:
-  - changelogs
-  - 1.25
 major_minor: 1.25
 version: 1.25.2
 ---

--- a/content/en/changelogs/1.25.2-changelog.md
+++ b/content/en/changelogs/1.25.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.25
-changelog_title: Version 1.25.2
+title: Spinnaker Release 1.25.2
 date: 2021-03-09 07:57:50 +0000
 tags:
   - changelogs
   - 1.25
+major_minor: 1.25
 version: 1.25.2
 ---
 

--- a/content/en/changelogs/1.25.3-changelog.md
+++ b/content/en/changelogs/1.25.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.25.3
 date: 2021-03-22 20:40:39 +0000
-tags:
-  - changelogs
-  - 1.25
 major_minor: 1.25
 version: 1.25.3
 ---

--- a/content/en/changelogs/1.25.3-changelog.md
+++ b/content/en/changelogs/1.25.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.25
-changelog_title: Version 1.25.3
+title: Spinnaker Release 1.25.3
 date: 2021-03-22 20:40:39 +0000
 tags:
   - changelogs
   - 1.25
+major_minor: 1.25
 version: 1.25.3
 ---
 

--- a/content/en/changelogs/1.25.4-changelog.md
+++ b/content/en/changelogs/1.25.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.25.4
 date: 2021-04-01 02:38:40 +0000
-tags:
-  - changelogs
-  - 1.25
 major_minor: 1.25
 version: 1.25.4
 ---

--- a/content/en/changelogs/1.25.4-changelog.md
+++ b/content/en/changelogs/1.25.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.25
-changelog_title: Version 1.25.4
+title: Spinnaker Release 1.25.4
 date: 2021-04-01 02:38:40 +0000
 tags:
   - changelogs
   - 1.25
+major_minor: 1.25
 version: 1.25.4
 ---
 

--- a/content/en/changelogs/1.25.5-changelog.md
+++ b/content/en/changelogs/1.25.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.25
-changelog_title: Version 1.25.5
+title: Spinnaker Release 1.25.5
 date: 2021-05-27 09:04:10 +0000
 tags:
   - changelogs
   - 1.25
+major_minor: 1.25
 version: 1.25.5
 ---
 

--- a/content/en/changelogs/1.25.5-changelog.md
+++ b/content/en/changelogs/1.25.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.25.5
 date: 2021-05-27 09:04:10 +0000
-tags:
-  - changelogs
-  - 1.25
 major_minor: 1.25
 version: 1.25.5
 ---

--- a/content/en/changelogs/1.25.6-changelog.md
+++ b/content/en/changelogs/1.25.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.25
-changelog_title: Version 1.25.6
+title: Spinnaker Release 1.25.6
 date: 2021-06-18 20:22:00 +0000
 tags:
   - changelogs
   - 1.25
+major_minor: 1.25
 version: 1.25.6
 ---
 

--- a/content/en/changelogs/1.25.6-changelog.md
+++ b/content/en/changelogs/1.25.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.25.6
 date: 2021-06-18 20:22:00 +0000
-tags:
-  - changelogs
-  - 1.25
 major_minor: 1.25
 version: 1.25.6
 ---

--- a/content/en/changelogs/1.25.7-changelog.md
+++ b/content/en/changelogs/1.25.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.25
-changelog_title: Version 1.25.7
+title: Spinnaker Release 1.25.7
 date: 2021-06-26 08:01:26 +0000
 tags:
   - changelogs
   - 1.25
+major_minor: 1.25
 version: 1.25.7
 ---
 

--- a/content/en/changelogs/1.25.7-changelog.md
+++ b/content/en/changelogs/1.25.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.25.7
 date: 2021-06-26 08:01:26 +0000
-tags:
-  - changelogs
-  - 1.25
 major_minor: 1.25
 version: 1.25.7
 ---

--- a/content/en/changelogs/1.25.8-changelog.md
+++ b/content/en/changelogs/1.25.8-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.25
-changelog_title: Version 1.25.8
+title: Spinnaker Release 1.25.8
 date: 2021-12-15 00:50:12 +0000
 tags:
   - changelogs
   - 1.25
+major_minor: 1.25
 version: 1.25.8
 ---
 

--- a/content/en/changelogs/1.25.8-changelog.md
+++ b/content/en/changelogs/1.25.8-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.25.8
 date: 2021-12-15 00:50:12 +0000
-tags:
-  - changelogs
-  - 1.25
 major_minor: 1.25
 version: 1.25.8
 ---

--- a/content/en/changelogs/1.26.0-changelog.md
+++ b/content/en/changelogs/1.26.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.26.0
 date: 2021-04-23 22:04:51 +0000
-tags:
-  - changelogs
-  - 1.26
 major_minor: 1.26
 version: 1.26.0
 ---

--- a/content/en/changelogs/1.26.0-changelog.md
+++ b/content/en/changelogs/1.26.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.26
-changelog_title: Version 1.26.0
+title: Spinnaker Release 1.26.0
 date: 2021-04-23 22:04:51 +0000
 tags:
   - changelogs
   - 1.26
+major_minor: 1.26
 version: 1.26.0
 ---
 

--- a/content/en/changelogs/1.26.1-changelog.md
+++ b/content/en/changelogs/1.26.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.26.1
 date: 2021-04-29 18:34:42 +0000
-tags:
-  - changelogs
-  - 1.26
 major_minor: 1.26
 version: 1.26.1
 ---

--- a/content/en/changelogs/1.26.1-changelog.md
+++ b/content/en/changelogs/1.26.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.26
-changelog_title: Version 1.26.1
+title: Spinnaker Release 1.26.1
 date: 2021-04-29 18:34:42 +0000
 tags:
   - changelogs
   - 1.26
+major_minor: 1.26
 version: 1.26.1
 ---
 

--- a/content/en/changelogs/1.26.2-changelog.md
+++ b/content/en/changelogs/1.26.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.26
-changelog_title: Version 1.26.2
+title: Spinnaker Release 1.26.2
 date: 2021-05-03 23:49:27 +0000
 tags:
   - changelogs
   - 1.26
+major_minor: 1.26
 version: 1.26.2
 ---
 

--- a/content/en/changelogs/1.26.2-changelog.md
+++ b/content/en/changelogs/1.26.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.26.2
 date: 2021-05-03 23:49:27 +0000
-tags:
-  - changelogs
-  - 1.26
 major_minor: 1.26
 version: 1.26.2
 ---

--- a/content/en/changelogs/1.26.3-changelog.md
+++ b/content/en/changelogs/1.26.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.26
-changelog_title: Version 1.26.3
+title: Spinnaker Release 1.26.3
 date: 2021-05-13 19:16:04 +0000
 tags:
   - changelogs
   - 1.26
+major_minor: 1.26
 version: 1.26.3
 ---
 

--- a/content/en/changelogs/1.26.3-changelog.md
+++ b/content/en/changelogs/1.26.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.26.3
 date: 2021-05-13 19:16:04 +0000
-tags:
-  - changelogs
-  - 1.26
 major_minor: 1.26
 version: 1.26.3
 ---

--- a/content/en/changelogs/1.26.4-changelog.md
+++ b/content/en/changelogs/1.26.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.26
-changelog_title: Version 1.26.4
+title: Spinnaker Release 1.26.4
 date: 2021-06-18 20:39:56 +0000
 tags:
   - changelogs
   - 1.26
+major_minor: 1.26
 version: 1.26.4
 ---
 

--- a/content/en/changelogs/1.26.4-changelog.md
+++ b/content/en/changelogs/1.26.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.26.4
 date: 2021-06-18 20:39:56 +0000
-tags:
-  - changelogs
-  - 1.26
 major_minor: 1.26
 version: 1.26.4
 ---

--- a/content/en/changelogs/1.26.5-changelog.md
+++ b/content/en/changelogs/1.26.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.26.5
 date: 2021-07-01 00:49:04 +0000
-tags:
-  - changelogs
-  - 1.26
 major_minor: 1.26
 version: 1.26.5
 ---

--- a/content/en/changelogs/1.26.5-changelog.md
+++ b/content/en/changelogs/1.26.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.26
-changelog_title: Version 1.26.5
+title: Spinnaker Release 1.26.5
 date: 2021-07-01 00:49:04 +0000
 tags:
   - changelogs
   - 1.26
+major_minor: 1.26
 version: 1.26.5
 ---
 

--- a/content/en/changelogs/1.26.6-changelog.md
+++ b/content/en/changelogs/1.26.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.26
-changelog_title: Version 1.26.6
+title: Spinnaker Release 1.26.6
 date: 2021-07-01 00:49:04 +0000
 tags:
   - changelogs
   - 1.26
+major_minor: 1.26
 version: 1.26.6
 ---
 

--- a/content/en/changelogs/1.26.6-changelog.md
+++ b/content/en/changelogs/1.26.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.26.6
 date: 2021-07-01 00:49:04 +0000
-tags:
-  - changelogs
-  - 1.26
 major_minor: 1.26
 version: 1.26.6
 ---

--- a/content/en/changelogs/1.26.7-changelog.md
+++ b/content/en/changelogs/1.26.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.26.7
 date: 2021-12-15 01:05:17 +0000
-tags:
-  - changelogs
-  - 1.26
 major_minor: 1.26
 version: 1.26.7
 ---

--- a/content/en/changelogs/1.26.7-changelog.md
+++ b/content/en/changelogs/1.26.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.26
-changelog_title: Version 1.26.7
+title: Spinnaker Release 1.26.7
 date: 2021-12-15 01:05:17 +0000
 tags:
   - changelogs
   - 1.26
+major_minor: 1.26
 version: 1.26.7
 ---
 

--- a/content/en/changelogs/1.27.0-changelog.md
+++ b/content/en/changelogs/1.27.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.27.0
 date: 2022-05-02 23:37:12 +0000
-tags:
-  - changelogs
-  - 1.27
 major_minor: 1.27
 version: 1.27.0
 ---

--- a/content/en/changelogs/1.27.0-changelog.md
+++ b/content/en/changelogs/1.27.0-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.27
-changelog_title: Version 1.27.0
+title: Spinnaker Release 1.27.0
 date: 2022-05-02 23:37:12 +0000
 tags:
   - changelogs
   - 1.27
+major_minor: 1.27
 version: 1.27.0
 ---
 

--- a/content/en/changelogs/1.3.0-changelog.md
+++ b/content/en/changelogs/1.3.0-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.3
-changelog_title: Version 1.3.0
+title: Spinnaker Release 1.3.0
 date: 2017-09-07 21:28:06
 tags:
   - changelogs
   - 1.3
+major_minor: 1.3
+version: 1.3.0
 ---
 
 **Version 1.3.0 requires Halyard v0.34.0+**

--- a/content/en/changelogs/1.3.0-changelog.md
+++ b/content/en/changelogs/1.3.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.3.0
 date: 2017-09-07 21:28:06
-tags:
-  - changelogs
-  - 1.3
 major_minor: 1.3
 version: 1.3.0
 ---

--- a/content/en/changelogs/1.3.1-changelog.md
+++ b/content/en/changelogs/1.3.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.3.1
 date: 2017-09-18 16:48:39
-tags:
-  - changelogs
-  - 1.3
 major_minor: 1.3
 version: 1.3.1
 ---

--- a/content/en/changelogs/1.3.1-changelog.md
+++ b/content/en/changelogs/1.3.1-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.3
-changelog_title: Version 1.3.1
+title: Spinnaker Release 1.3.1
 date: 2017-09-18 16:48:39
 tags:
   - changelogs
   - 1.3
+major_minor: 1.3
+version: 1.3.1
 ---
 
 <script src="https://gist.github.com/spinnaker-release/021ff67e0ef7a4e1b271e0ea4344b3b4.js"></script>

--- a/content/en/changelogs/1.4.0-changelog.md
+++ b/content/en/changelogs/1.4.0-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.4
-changelog_title: Version 1.4.0
+title: Spinnaker Release 1.4.0
 date: 2017-09-21 20:00:11
 tags:
   - changelogs
   - 1.4
+major_minor: 1.4
+version: 1.4.0
 ---
 
 <script src="https://gist.github.com/spinnaker-release/52f2f6660077125e05808583c5bf63ee.js"></script>

--- a/content/en/changelogs/1.4.0-changelog.md
+++ b/content/en/changelogs/1.4.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.4.0
 date: 2017-09-21 20:00:11
-tags:
-  - changelogs
-  - 1.4
 major_minor: 1.4
 version: 1.4.0
 ---

--- a/content/en/changelogs/1.4.1-changelog.md
+++ b/content/en/changelogs/1.4.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.4.1
 date: 2017-09-22 18:13:32
-tags:
-  - changelogs
-  - 1.4
 major_minor: 1.4
 version: 1.4.1
 ---

--- a/content/en/changelogs/1.4.1-changelog.md
+++ b/content/en/changelogs/1.4.1-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.4
-changelog_title: Version 1.4.1
+title: Spinnaker Release 1.4.1
 date: 2017-09-22 18:13:32
 tags:
   - changelogs
   - 1.4
+major_minor: 1.4
+version: 1.4.1
 ---
 
 <script src="https://gist.github.com/spinnaker-release/87ffcdd472d315d75877312de01bb05d.js"></script>

--- a/content/en/changelogs/1.4.2-changelog.md
+++ b/content/en/changelogs/1.4.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.4.2
 date: 2017-10-03 17:27:27
-tags:
-  - changelogs
-  - 1.4
 major_minor: 1.4
 version: 1.4.2
 ---

--- a/content/en/changelogs/1.4.2-changelog.md
+++ b/content/en/changelogs/1.4.2-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.4
-changelog_title: Version 1.4.2
+title: Spinnaker Release 1.4.2
 date: 2017-10-03 17:27:27
 tags:
   - changelogs
   - 1.4
+major_minor: 1.4
+version: 1.4.2
 ---
 
 <script src="https://gist.github.com/spinnaker-release/c791562094c040e936776b501b42c7a6.js"></script>

--- a/content/en/changelogs/1.5.0-changelog.md
+++ b/content/en/changelogs/1.5.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.5.0
 date: 2017-11-08 18:50:36
-tags:
-  - changelogs
-  - 1.5
 major_minor: 1.5
 version: 1.5.0
 ---

--- a/content/en/changelogs/1.5.0-changelog.md
+++ b/content/en/changelogs/1.5.0-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.5
-changelog_title: Version 1.5.0
+title: Spinnaker Release 1.5.0
 date: 2017-11-08 18:50:36
 tags:
   - changelogs
   - 1.5
+major_minor: 1.5
+version: 1.5.0
 ---
 
 <script src="https://gist.github.com/spinnaker-release/d3d2ca93ebcc0fce546323723dee65ea.js"></script>

--- a/content/en/changelogs/1.5.1-changelog.md
+++ b/content/en/changelogs/1.5.1-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.5
-changelog_title: Version 1.5.1
+title: Spinnaker Release 1.5.1
 date: 2017-11-30 21:48:29
 tags:
   - changelogs
   - 1.5
+major_minor: 1.5
+version: 1.5.1
 ---
 
 <script src="https://gist.github.com/spinnaker-release/e884c78db5dead1a72c3f6b52c05738b.js"></script>

--- a/content/en/changelogs/1.5.1-changelog.md
+++ b/content/en/changelogs/1.5.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.5.1
 date: 2017-11-30 21:48:29
-tags:
-  - changelogs
-  - 1.5
 major_minor: 1.5
 version: 1.5.1
 ---

--- a/content/en/changelogs/1.5.2-changelog.md
+++ b/content/en/changelogs/1.5.2-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.5
-changelog_title: Version 1.5.2
+title: Spinnaker Release 1.5.2
 date: 2017-12-22 17:30:58
 tags:
   - changelogs
   - 1.5
+major_minor: 1.5
+version: 1.5.2
 ---
 
 <script src="https://gist.github.com/spinnaker-release/a2c02795c6239cc04118fa62de46d2ef.js"></script>

--- a/content/en/changelogs/1.5.2-changelog.md
+++ b/content/en/changelogs/1.5.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.5.2
 date: 2017-12-22 17:30:58
-tags:
-  - changelogs
-  - 1.5
 major_minor: 1.5
 version: 1.5.2
 ---

--- a/content/en/changelogs/1.5.3-changelog.md
+++ b/content/en/changelogs/1.5.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.5.3
 date: 2018-01-09 20:55:22
-tags:
-  - changelogs
-  - 1.5
 major_minor: 1.5
 version: 1.5.3
 ---

--- a/content/en/changelogs/1.5.3-changelog.md
+++ b/content/en/changelogs/1.5.3-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.5
-changelog_title: Version 1.5.3
+title: Spinnaker Release 1.5.3
 date: 2018-01-09 20:55:22
 tags:
   - changelogs
   - 1.5
+major_minor: 1.5
+version: 1.5.3
 ---
 
 <script src="https://gist.github.com/spinnaker-release/cdcbfd25eaa81464a4932cbb1f7c70e8.js"></script>

--- a/content/en/changelogs/1.5.4-changelog.md
+++ b/content/en/changelogs/1.5.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.5.4
 date: 2018-01-10 18:45:23
-tags:
-  - changelogs
-  - 1.5
 major_minor: 1.5
 version: 1.5.4
 ---

--- a/content/en/changelogs/1.5.4-changelog.md
+++ b/content/en/changelogs/1.5.4-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.5
-changelog_title: Version 1.5.4
+title: Spinnaker Release 1.5.4
 date: 2018-01-10 18:45:23
 tags:
   - changelogs
   - 1.5
+major_minor: 1.5
+version: 1.5.4
 ---
 
 <script src="https://gist.github.com/spinnaker-release/6b9fd632caeaefd32246074998af8498.js"></script>

--- a/content/en/changelogs/1.6.0-changelog.md
+++ b/content/en/changelogs/1.6.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.6.0
 date: 2018-02-21 22:23:08
-tags:
-  - changelogs
-  - 1.6
 major_minor: 1.6
 version: 1.6.0
 ---

--- a/content/en/changelogs/1.6.0-changelog.md
+++ b/content/en/changelogs/1.6.0-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.6
-changelog_title: Version 1.6.0
+title: Spinnaker Release 1.6.0
 date: 2018-02-21 22:23:08
 tags:
   - changelogs
   - 1.6
+major_minor: 1.6
+version: 1.6.0
 ---
 
 <script src="https://gist.github.com/spinnaker-release/235774d2d17f3bd96d3ed6c446b065a4.js"></script>

--- a/content/en/changelogs/1.6.1-changelog.md
+++ b/content/en/changelogs/1.6.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.6.1
 date: 2018-04-04 15:21:03
-tags:
-  - changelogs
-  - 1.6
 major_minor: 1.6
 version: 1.6.1
 ---

--- a/content/en/changelogs/1.6.1-changelog.md
+++ b/content/en/changelogs/1.6.1-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.6
-changelog_title: Version 1.6.1
+title: Spinnaker Release 1.6.1
 date: 2018-04-04 15:21:03
 tags:
   - changelogs
   - 1.6
+major_minor: 1.6
+version: 1.6.1
 ---
 
 # Spinnaker 1.6.1

--- a/content/en/changelogs/1.6.2-changelog.md
+++ b/content/en/changelogs/1.6.2-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.6
-changelog_title: Version 1.6.2
+title: Spinnaker Release 1.6.2
 date: 2018-07-26 17:55:39
 tags:
   - changelogs
   - 1.6
+major_minor: 1.6
+version: 1.6.2
 ---
 
 # Spinnaker 1.6.2

--- a/content/en/changelogs/1.6.2-changelog.md
+++ b/content/en/changelogs/1.6.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.6.2
 date: 2018-07-26 17:55:39
-tags:
-  - changelogs
-  - 1.6
 major_minor: 1.6
 version: 1.6.2
 ---

--- a/content/en/changelogs/1.7.0-changelog.md
+++ b/content/en/changelogs/1.7.0-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.7
-changelog_title: Version 1.7.0
+title: Spinnaker Release 1.7.0
 date: 2018-04-25 12:06:36
 tags:
   - changelogs
   - 1.7
+major_minor: 1.7
+version: 1.7.0
 ---
 
 # Spinnaker 1.7.0

--- a/content/en/changelogs/1.7.0-changelog.md
+++ b/content/en/changelogs/1.7.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.7.0
 date: 2018-04-25 12:06:36
-tags:
-  - changelogs
-  - 1.7
 major_minor: 1.7
 version: 1.7.0
 ---

--- a/content/en/changelogs/1.7.1-changelog.md
+++ b/content/en/changelogs/1.7.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.7.1
 date: 2018-04-30 13:27:47
-tags:
-  - changelogs
-  - 1.7
 major_minor: 1.7
 version: 1.7.1
 ---

--- a/content/en/changelogs/1.7.1-changelog.md
+++ b/content/en/changelogs/1.7.1-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.7
-changelog_title: Version 1.7.1
+title: Spinnaker Release 1.7.1
 date: 2018-04-30 13:27:47
 tags:
   - changelogs
   - 1.7
+major_minor: 1.7
+version: 1.7.1
 ---
 
 # Spinnaker 1.7.1

--- a/content/en/changelogs/1.7.2-changelog.md
+++ b/content/en/changelogs/1.7.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.7.2
 date: 2018-05-01 11:22:26
-tags:
-  - changelogs
-  - 1.7
 major_minor: 1.7
 version: 1.7.2
 ---

--- a/content/en/changelogs/1.7.2-changelog.md
+++ b/content/en/changelogs/1.7.2-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.7
-changelog_title: Version 1.7.2
+title: Spinnaker Release 1.7.2
 date: 2018-05-01 11:22:26
 tags:
   - changelogs
   - 1.7
+major_minor: 1.7
+version: 1.7.2
 ---
 
 # Spinnaker 1.7.2

--- a/content/en/changelogs/1.7.3-changelog.md
+++ b/content/en/changelogs/1.7.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.7.3
 date: 2018-05-07 13:26:10
-tags:
-  - changelogs
-  - 1.7
 major_minor: 1.7
 version: 1.7.3
 ---

--- a/content/en/changelogs/1.7.3-changelog.md
+++ b/content/en/changelogs/1.7.3-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.7
-changelog_title: Version 1.7.3
+title: Spinnaker Release 1.7.3
 date: 2018-05-07 13:26:10
 tags:
   - changelogs
   - 1.7
+major_minor: 1.7
+version: 1.7.3
 ---
 
 # Spinnaker 1.7.3

--- a/content/en/changelogs/1.7.4-changelog.md
+++ b/content/en/changelogs/1.7.4-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.7
-changelog_title: Version 1.7.4
+title: Spinnaker Release 1.7.4
 date: 2018-05-14 13:03:48
 tags:
   - changelogs
   - 1.7
+major_minor: 1.7
+version: 1.7.4
 ---
 
 # Spinnaker 1.7.4

--- a/content/en/changelogs/1.7.4-changelog.md
+++ b/content/en/changelogs/1.7.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.7.4
 date: 2018-05-14 13:03:48
-tags:
-  - changelogs
-  - 1.7
 major_minor: 1.7
 version: 1.7.4
 ---

--- a/content/en/changelogs/1.7.5-changelog.md
+++ b/content/en/changelogs/1.7.5-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.7
-changelog_title: Version 1.7.5
+title: Spinnaker Release 1.7.5
 date: 2018-05-21 11:14:10
 tags:
   - changelogs
   - 1.7
+major_minor: 1.7
+version: 1.7.5
 ---
 
 # Spinnaker 1.7.5

--- a/content/en/changelogs/1.7.5-changelog.md
+++ b/content/en/changelogs/1.7.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.7.5
 date: 2018-05-21 11:14:10
-tags:
-  - changelogs
-  - 1.7
 major_minor: 1.7
 version: 1.7.5
 ---

--- a/content/en/changelogs/1.7.6-changelog.md
+++ b/content/en/changelogs/1.7.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.7.6
 date: 2018-05-29 12:26:28
-tags:
-  - changelogs
-  - 1.7
 major_minor: 1.7
 version: 1.7.6
 ---

--- a/content/en/changelogs/1.7.6-changelog.md
+++ b/content/en/changelogs/1.7.6-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.7
-changelog_title: Version 1.7.6
+title: Spinnaker Release 1.7.6
 date: 2018-05-29 12:26:28
 tags:
   - changelogs
   - 1.7
+major_minor: 1.7
+version: 1.7.6
 ---
 
 # Spinnaker 1.7.6

--- a/content/en/changelogs/1.7.7-changelog.md
+++ b/content/en/changelogs/1.7.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.7.7
 date: 2018-07-26 17:28:13
-tags:
-  - changelogs
-  - 1.7
 major_minor: 1.7
 version: 1.7.7
 ---

--- a/content/en/changelogs/1.7.7-changelog.md
+++ b/content/en/changelogs/1.7.7-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.7
-changelog_title: Version 1.7.7
+title: Spinnaker Release 1.7.7
 date: 2018-07-26 17:28:13
 tags:
   - changelogs
   - 1.7
+major_minor: 1.7
+version: 1.7.7
 ---
 
 # Spinnaker 1.7.7

--- a/content/en/changelogs/1.7.8-changelog.md
+++ b/content/en/changelogs/1.7.8-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.7
-changelog_title: Version 1.7.8
+title: Spinnaker Release 1.7.8
 date: 2018-08-29 15:10:06
 tags:
   - changelogs
   - 1.7
+major_minor: 1.7
 version: 1.7.8
 ---
 

--- a/content/en/changelogs/1.7.8-changelog.md
+++ b/content/en/changelogs/1.7.8-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.7.8
 date: 2018-08-29 15:10:06
-tags:
-  - changelogs
-  - 1.7
 major_minor: 1.7
 version: 1.7.8
 ---

--- a/content/en/changelogs/1.8.0-changelog.md
+++ b/content/en/changelogs/1.8.0-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.8
-changelog_title: Version 1.8.0
+title: Spinnaker Release 1.8.0
 date: 2018-06-22 13:48:39
 tags:
   - changelogs
   - 1.8
+major_minor: 1.8
+version: 1.8.0
 ---
 
 # Spinnaker 1.8.0

--- a/content/en/changelogs/1.8.0-changelog.md
+++ b/content/en/changelogs/1.8.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.8.0
 date: 2018-06-22 13:48:39
-tags:
-  - changelogs
-  - 1.8
 major_minor: 1.8
 version: 1.8.0
 ---

--- a/content/en/changelogs/1.8.1-changelog.md
+++ b/content/en/changelogs/1.8.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.8.1
 date: 2018-07-09 16:37:22
-tags:
-  - changelogs
-  - 1.8
 major_minor: 1.8
 version: 1.8.1
 ---

--- a/content/en/changelogs/1.8.1-changelog.md
+++ b/content/en/changelogs/1.8.1-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.8
-changelog_title: Version 1.8.1
+title: Spinnaker Release 1.8.1
 date: 2018-07-09 16:37:22
 tags:
   - changelogs
   - 1.8
+major_minor: 1.8
+version: 1.8.1
 ---
 
 # Spinnaker 1.8.1

--- a/content/en/changelogs/1.8.2-changelog.md
+++ b/content/en/changelogs/1.8.2-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.8
-changelog_title: Version 1.8.2
+title: Spinnaker Release 1.8.2
 date: 2018-07-23 10:54:30
 tags:
   - changelogs
   - 1.8
+major_minor: 1.8
+version: 1.8.2
 ---
 
 # Spinnaker 1.8.2

--- a/content/en/changelogs/1.8.2-changelog.md
+++ b/content/en/changelogs/1.8.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.8.2
 date: 2018-07-23 10:54:30
-tags:
-  - changelogs
-  - 1.8
 major_minor: 1.8
 version: 1.8.2
 ---

--- a/content/en/changelogs/1.8.3-changelog.md
+++ b/content/en/changelogs/1.8.3-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.8
-changelog_title: Version 1.8.3
+title: Spinnaker Release 1.8.3
 date: 2018-07-24 15:36:16
 tags:
   - changelogs
   - 1.8
+major_minor: 1.8
+version: 1.8.3
 ---
 
 # Spinnaker 1.8.3

--- a/content/en/changelogs/1.8.3-changelog.md
+++ b/content/en/changelogs/1.8.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.8.3
 date: 2018-07-24 15:36:16
-tags:
-  - changelogs
-  - 1.8
 major_minor: 1.8
 version: 1.8.3
 ---

--- a/content/en/changelogs/1.8.4-changelog.md
+++ b/content/en/changelogs/1.8.4-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.8
-changelog_title: Version 1.8.4
+title: Spinnaker Release 1.8.4
 date: 2018-07-26 16:26:58
 tags:
   - changelogs
   - 1.8
+major_minor: 1.8
+version: 1.8.4
 ---
 
 # Spinnaker 1.8.4

--- a/content/en/changelogs/1.8.4-changelog.md
+++ b/content/en/changelogs/1.8.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.8.4
 date: 2018-07-26 16:26:58
-tags:
-  - changelogs
-  - 1.8
 major_minor: 1.8
 version: 1.8.4
 ---

--- a/content/en/changelogs/1.8.5-changelog.md
+++ b/content/en/changelogs/1.8.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.8.5
 date: 2018-08-02 16:40:59
-tags:
-  - changelogs
-  - 1.8
 major_minor: 1.8
 version: 1.8.5
 ---

--- a/content/en/changelogs/1.8.5-changelog.md
+++ b/content/en/changelogs/1.8.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.8
-changelog_title: Version 1.8.5
+title: Spinnaker Release 1.8.5
 date: 2018-08-02 16:40:59
 tags:
   - changelogs
   - 1.8
+major_minor: 1.8
 version: 1.8.5
 ---
 

--- a/content/en/changelogs/1.8.6-changelog.md
+++ b/content/en/changelogs/1.8.6-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.8.6
 date: 2018-08-29 15:11:41
-tags:
-  - changelogs
-  - 1.8
 major_minor: 1.8
 version: 1.8.6
 ---

--- a/content/en/changelogs/1.8.6-changelog.md
+++ b/content/en/changelogs/1.8.6-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.8
-changelog_title: Version 1.8.6
+title: Spinnaker Release 1.8.6
 date: 2018-08-29 15:11:41
 tags:
   - changelogs
   - 1.8
+major_minor: 1.8
 version: 1.8.6
 ---
 

--- a/content/en/changelogs/1.8.7-changelog.md
+++ b/content/en/changelogs/1.8.7-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.8.7
 date: 2018-09-28 13:58:59
-tags:
-  - changelogs
-  - 1.8
 major_minor: 1.8
 version: 1.8.7
 ---

--- a/content/en/changelogs/1.8.7-changelog.md
+++ b/content/en/changelogs/1.8.7-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.8
-changelog_title: Version 1.8.7
+title: Spinnaker Release 1.8.7
 date: 2018-09-28 13:58:59
 tags:
   - changelogs
   - 1.8
+major_minor: 1.8
 version: 1.8.7
 ---
 

--- a/content/en/changelogs/1.9.0-changelog.md
+++ b/content/en/changelogs/1.9.0-changelog.md
@@ -1,10 +1,11 @@
 ---
-title: Version 1.9
-changelog_title: Version 1.9.0
+title: Spinnaker Release 1.9.0
 date: 2018-08-15 15:49:49
 tags:
   - changelogs
   - 1.9
+major_minor: 1.9
+version: 1.9.0
 ---
 
 <script src="https://gist.github.com/spinnaker-release/942a9ed21d2555ae15b82a036a140e3a.js"/>

--- a/content/en/changelogs/1.9.0-changelog.md
+++ b/content/en/changelogs/1.9.0-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.9.0
 date: 2018-08-15 15:49:49
-tags:
-  - changelogs
-  - 1.9
 major_minor: 1.9
 version: 1.9.0
 ---

--- a/content/en/changelogs/1.9.1-changelog.md
+++ b/content/en/changelogs/1.9.1-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.9.1
 date: 2018-08-28 10:13:57
-tags:
-  - changelogs
-  - 1.9
 major_minor: 1.9
 version: 1.9.1
 ---

--- a/content/en/changelogs/1.9.1-changelog.md
+++ b/content/en/changelogs/1.9.1-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.9
-changelog_title: Version 1.9.1
+title: Spinnaker Release 1.9.1
 date: 2018-08-28 10:13:57
 tags:
   - changelogs
   - 1.9
+major_minor: 1.9
 version: 1.9.1
 ---
 

--- a/content/en/changelogs/1.9.2-changelog.md
+++ b/content/en/changelogs/1.9.2-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.9
-changelog_title: Version 1.9.2
+title: Spinnaker Release 1.9.2
 date: 2018-08-29 16:08:26
 tags:
   - changelogs
   - 1.9
+major_minor: 1.9
 version: 1.9.2
 ---
 

--- a/content/en/changelogs/1.9.2-changelog.md
+++ b/content/en/changelogs/1.9.2-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.9.2
 date: 2018-08-29 16:08:26
-tags:
-  - changelogs
-  - 1.9
 major_minor: 1.9
 version: 1.9.2
 ---

--- a/content/en/changelogs/1.9.3-changelog.md
+++ b/content/en/changelogs/1.9.3-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.9
-changelog_title: Version 1.9.3
+title: Spinnaker Release 1.9.3
 date: 2018-09-10 12:14:09
 tags:
   - changelogs
   - 1.9
+major_minor: 1.9
 version: 1.9.3
 ---
 

--- a/content/en/changelogs/1.9.3-changelog.md
+++ b/content/en/changelogs/1.9.3-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.9.3
 date: 2018-09-10 12:14:09
-tags:
-  - changelogs
-  - 1.9
 major_minor: 1.9
 version: 1.9.3
 ---

--- a/content/en/changelogs/1.9.4-changelog.md
+++ b/content/en/changelogs/1.9.4-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.9.4
 date: 2018-09-26 11:33:02
-tags:
-  - changelogs
-  - 1.9
 major_minor: 1.9
 version: 1.9.4
 ---

--- a/content/en/changelogs/1.9.4-changelog.md
+++ b/content/en/changelogs/1.9.4-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.9
-changelog_title: Version 1.9.4
+title: Spinnaker Release 1.9.4
 date: 2018-09-26 11:33:02
 tags:
   - changelogs
   - 1.9
+major_minor: 1.9
 version: 1.9.4
 ---
 

--- a/content/en/changelogs/1.9.5-changelog.md
+++ b/content/en/changelogs/1.9.5-changelog.md
@@ -1,10 +1,10 @@
 ---
-title: Version 1.9
-changelog_title: Version 1.9.5
+title: Spinnaker Release 1.9.5
 date: 2018-10-01 13:15:45
 tags:
   - changelogs
   - 1.9
+major_minor: 1.9
 version: 1.9.5
 ---
 

--- a/content/en/changelogs/1.9.5-changelog.md
+++ b/content/en/changelogs/1.9.5-changelog.md
@@ -1,9 +1,6 @@
 ---
 title: Spinnaker Release 1.9.5
 date: 2018-10-01 13:15:45
-tags:
-  - changelogs
-  - 1.9
 major_minor: 1.9
 version: 1.9.5
 ---

--- a/layouts/changelogs/baseof.html
+++ b/layouts/changelogs/baseof.html
@@ -1,18 +1,23 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
-  <head>
-    {{ partial "head.html" . }}
-  </head>
-  <body class="td-{{ .Kind }} layout-{{.Layout}}">
-    <header>{{ partial "navbar.html" . }}</header>
 
-    <div class="td-default td-outer container">
-      <main role="main" class="clear-header">
-        <h1>{{ .Params.title}}</h1>
+<head>
+  {{ partial "head.html" . }}
+</head>
+
+<body class="td-{{ .Kind }} layout-{{.Layout}}">
+  <header>{{ partial "navbar.html" . }}</header>
+
+  <div class="td-default td-outer clear-header container">
+    <main role="main">
+      <div class="td-content">
+        <h1>{{ .Title }}</h1>
         {{ block "main" . }} {{ end }}
-      </main>
-      {{ partial "footer.html" . }}
-    </div>
-    {{ partialCached "scripts.html" . }}
-  </body>
+      </div>
+    </main>
+    {{ partial "footer.html" . }}
+  </div>
+  {{ partialCached "scripts.html" . }}
+</body>
+
 </html>

--- a/layouts/shortcodes/deprecated-versions.html
+++ b/layouts/shortcodes/deprecated-versions.html
@@ -8,17 +8,15 @@ For example:
 
 <!--
 1. get all changelogs as defined in Section
-2. filter where version key not defined in frontmatter (very old versions).
-   These will never be the latest stable and make later steps hard.
-3. group by major.minor (eg: 1.26, 1.27) as defined in Page Title.
+2. group by major.minor (eg: 1.26, 1.27) as defined in major_minor param.
 -->
-{{ $versioned_changelogs := (where (where $.Site.RegularPages "Section" "changelogs") "Params.version" "!=" nil).GroupBy "Title" }}
+{{ $grouped_changelogs := (where $.Site.RegularPages "Section" "changelogs").GroupByParam "major_minor" }}
 
 <!-- declare slice of latest patch versions for each major.minor -->
 {{ $latest_major_minors := slice }}
 
 <!-- add our latest major.minor to slice -->
-{{ range $versioned_changelogs }}
+{{ range $grouped_changelogs }}
 {{ range first 1 (.Pages.ByParam "version").Reverse }}
 {{ $latest_major_minors = $latest_major_minors | append .Page }}
 {{ end }}
@@ -31,7 +29,7 @@ For example:
 
 {{ range $deprecated }}
 <div class="my-3">
-  <h4>{{.Params.changelog_title}}</h4>
+  <h4>{{.Params.version}}</h4>
   <span>Released: {{.Date.UTC}}</span>
   <a href="{{.RelPermalink}}" target="_blank">Changelog</a>
 </div>

--- a/layouts/shortcodes/latest-stable.html
+++ b/layouts/shortcodes/latest-stable.html
@@ -8,17 +8,15 @@ For example:
 
 <!--
 1. get all changelogs as defined in Section
-2. filter where version key not defined in frontmatter (very old versions).
-   These will never be the latest stable and make later steps hard.
-3. group by major.minor (eg: 1.26, 1.27) as defined in Page Title.
+2. group by major.minor (eg: 1.26, 1.27) as defined in major_minor param.
 -->
-{{ $versioned_changelogs := (where (where $.Site.RegularPages "Section" "changelogs") "Params.version" "!=" nil).GroupBy "Title" }}
+{{ $grouped_changelogs := (where $.Site.RegularPages "Section" "changelogs").GroupByParam "major_minor" }}
 
 <!-- declare slice of latest patch versions for each major.minor -->
 {{ $latest_major_minors := slice }}
 
 <!-- add our latest major.minor to slice -->
-{{ range $versioned_changelogs }}
+{{ range $grouped_changelogs }}
 {{ range first 1 (.Pages.ByParam "version").Reverse }}
 {{ $latest_major_minors = $latest_major_minors | append .Page }}
 {{ end }}
@@ -29,7 +27,7 @@ For example:
 <!-- print out our template section for each stable version -->
 {{ range sort ($latest_stables).ByTitle.Reverse }}
 <div class="my-3">
-  <h4>{{.Params.changelog_title}}</h4>
+  <h4>{{.Params.version}}</h4>
   <span>Released: {{.Params.date.UTC}}</span>
   <a href="{{.RelPermalink}}">Changelog</a>
 </div>


### PR DESCRIPTION
Part of: https://github.com/spinnaker/spinnaker/issues/6678

- remove hack for missing `version:` key
- add a `major_minor` key so we can group by this to find latest patch
  release for a given `major_minor`
- use `title:` field for actual titles as going forward each changelog
  will be for a single release version (markdown, not gist embedding)

**Example Versions list with a mixture of gist and md changelogs:**
![spinnaker-versions-list](https://user-images.githubusercontent.com/96093759/176588443-ca1a14e8-e479-471e-aa1d-8eacbaf02601.png)

**Example markdown changelog:**
![spinnaker-1 28 0-changelog](https://user-images.githubusercontent.com/96093759/176588438-e35c2b85-efd5-4e6b-9e62-e95cc5a994b3.png)

