### PR TITLE
Remove duplicate paragraph on “Concepts” page

### DIFF
--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -6,9 +6,6 @@ description: >
   Spinnaker is an open-source, multi-cloud continuous delivery platform that helps you release software changes with high velocity and confidence.
 ---
 
-Spinnaker is an open-source, multi-cloud continuous delivery platform that helps
-you release software changes with high velocity and confidence.
-
 Spinnaker provides two core sets of features:
 
 * [Application management](#application-management)


### PR DESCRIPTION
It looks like the description is used as the opening paragraph of the page, which lead to the same paragraph appearing twice in a row.

<img width="741" alt="CleanShot 2022-07-25 at 16 01 33@2x" src="https://user-images.githubusercontent.com/34030/180805629-e03c9271-448b-4f62-a4b0-4560806fea68.png">

