### PR TITLE
DOCs table of contents positioning bug

### DIFF
--- a/assets/scss/docs.scss
+++ b/assets/scss/docs.scss
@@ -13,3 +13,13 @@
     margin-top: 50px;
   }
 }
+.td-toc {
+  &.bumped {
+    top: 0;
+    .td-page-meta,
+    #TableOfContents {
+      position: relative;
+      top: 50px;
+    }
+  }
+}

--- a/static/js/promo-banner.js
+++ b/static/js/promo-banner.js
@@ -1,9 +1,10 @@
 const promoBanner = document.getElementById('promo-banner')
 const closePromoBanner = document.getElementById('close-banner')
 const navbar = document.getElementById('navbar')
-
+const tdTocWrapper = document.querySelector('.td-toc')
+// const docsSidebarMeta = document.querySelector('.td-page-meta')
+console.log({ tdTocWrapper })
 if (promoBanner) {
-  console.log('promo banner')
   closePromoBanner.addEventListener('click', () => {
     // Close banner
     promoBanner.classList.remove('active')
@@ -11,11 +12,13 @@ if (promoBanner) {
     // Drop cookie to keep banner closed 24 hours for user
     createCookie('banner_closed', 1, 1)
     navbar.style.top = '0px'
+    tdTocWrapper.classList.remove('bumped')
   })
 
   if (!readCookie('banner_closed')) {
     // Show promo banner if no "closed_banner" cookie
     promoBanner.classList.add('active')
+    tdTocWrapper.classList.add('bumped')
 
     // Adjust navbar position after promo banner appears
     setTimeout(() => {


### PR DESCRIPTION
Added conditionals to the DOCs table of contents css classes to bump down if banner is present and snap back to normal positioning when banner is removed.