### PR TITLE
Add JSON schema for UserSecretMetadata

### DIFF
--- a/content/en/2022/08/UserSecretMetadata.schema.json
+++ b/content/en/2022/08/UserSecretMetadata.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spinnaker.io/2022/08/UserSecretMetadata.schema.json",
+  "title": "UserSecretMetadata",
+  "description": "Describes metadata corresponding to a UserSecret.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "The type of user secret contained in the external secret payload.",
+      "type": "string"
+    },
+    "encoding": {
+      "description": "The encoding format of the secret payload.",
+      "type": "string",
+      "example": "opaque"
+    },
+    "roles": {
+      "description": "The set of roles authorized to use this secret.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    }
+  },
+  "required": [
+    "type", "roles"
+  ]
+}


### PR DESCRIPTION
This makes it easier to validate the format of user secret metadata by
verifying it matches a known schema.

Relates to https://github.com/spinnaker/kork/pull/974 and previous Kork PRs around user secrets.