### PR TITLE
docs(fix): Fixed Azure Service Principal command to include the subscription scope

### DIFF
--- a/content/en/docs/setup/install/providers/azure.md
+++ b/content/en/docs/setup/install/providers/azure.md
@@ -37,7 +37,7 @@ az account set --subscription $SUBSCRIPTION_ID
 Next, create a Service Principal (where the name is unique in your subscription) and set environment variables based on the output:
 
 ```bash
-az ad sp create-for-rbac --name "Spinnaker"
+az ad sp create-for-rbac --name "Spinnaker" --role contributor --scopes /subscriptions/${SUBSCRIPTION_ID}
 APP_ID=<Insert App Id>
 TENANT_ID=<Insert Tenant Id>
 ```


### PR DESCRIPTION
Resolves the following issue:

```bash
hal config provider azure account add my-azure-account \
  --client-id $APP_ID \
  --tenant-id $TENANT_ID \
  --subscription-id $SUBSCRIPTION_ID \
  --default-key-vault $VAULT_NAME \
  --default-resource-group $RESOURCE_GROUP \
  --packer-resource-group $RESOURCE_GROUP \
  --app-key
The appKey (password) of your service principal.:
+ Get current deployment
  Success
- Add the my-azure-account account
  Failure
Validation in default.provider.azure:
! ERROR Error instantiating Azure credentials: The client
  'f00df00d-f00d-f00d-f00d-f00df00df00d' with object id
  'f00df00d-f00d-f00d-f00d-f00df00df00d' does not have authorization to perform
  action 'Microsoft.Resources/subscriptions/resources/read' over scope
  '/subscriptions/f00df00d-f00d-f00d-f00d-f00df00df00d' or the scope is invalid.
  If access was recently granted, please refresh your credentials.
? Follow instructions here https://aka.ms/azspinconfig to setup
  azure credentials.

- Failed to add account my-azure-account for provider azure.
```