### PR TITLE
Include official spinnaker plugins repo.

### DIFF
--- a/content/en/docs/guides/user/plugins-users/_index.md
+++ b/content/en/docs/guides/user/plugins-users/_index.md
@@ -272,4 +272,6 @@ See the [pf4jStagePlugin Deployment Example]({{< ref "plugin-deploy-example" >}}
 
 ## Resources
 
+A central [repository for all Spinnaker plugins](https://github.com/spinnaker/plugins) has been initiated and any new plugins would be added going forward.  
+
 You can ask for help with plugins in the [Spinnaker Slack's](https://join.spinnaker.io/) `#plugins` channel.


### PR DESCRIPTION
To include [spinnaker/plugins](https://github.com/spinnaker/plugins) repo under the reference section would be useful to the users who read through the plugin documentation.