### PR TITLE
Pipeline expressions - add undocumented readAllYaml function

### DIFF
--- a/content/en/docs/reference/pipeline/expressions/_index.md
+++ b/content/en/docs/reference/pipeline/expressions/_index.md
@@ -155,6 +155,10 @@ Converts a JSON String into a Map that can then be processed further.
 
 Converts a YAML String into a Map that can then be processed further.
 
+### #readAllYaml(String)
+
+Converts a multi-document YAML String into a list of Maps that can then be processed further.
+
 ### #fromUrl(String)
 
 Returns the contents of the specified URL as a String. You can use this


### PR DESCRIPTION
I came across a function that's useful but undocumented.

[Documentation](https://spinnaker.io/docs/reference/pipeline/expressions/)
[Code reference](https://github.com/spinnaker/orca/blob/3a0f45003cf80d441c6f044606234ee4d939029d/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java#L87)