### PR TITLE
docs(feat): Add Bitbucket webhook events as pipeline triggers

### DIFF
--- a/content/en/docs/guides/user/pipeline/triggers/artifactory/_index.md
+++ b/content/en/docs/guides/user/pipeline/triggers/artifactory/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Triggering pipelines with Artifactory"
 linkTitle: "JFrog Artifactory"
-weight:
 description: >
   Add a [JFrog Artifactory](https://jfrog.com/artifactory/) trigger to your pipeline.
 ---

--- a/content/en/docs/guides/user/pipeline/triggers/bitbucket-events.md
+++ b/content/en/docs/guides/user/pipeline/triggers/bitbucket-events.md
@@ -1,0 +1,40 @@
+---
+title: Triggering pipelines with Bitbucket Server
+linkTitle: Bitbucket
+description: >
+  Trigger Spinnaker pipelines based on Bitbucket Server webhook events.
+---
+
+## Overview of supported Bitbucket Server events
+
+Spinnaker supports the following Bitbucket Server webhook events:
+
+* Declined (pr:declined)
+* Deleted (pr:deleted)
+* Merged (pr:merged)
+* Modified/Source branch updated (pr:from_ref_updated)
+* Opened (pr:opened)
+* Push (repo:refs_changed)
+
+
+## Before you begin
+
+* You are familiar with [creating and triggering webhooks](https://confluence.atlassian.com/bitbucketserver/manage-webhooks-938025878.html) in Bithucket Server.
+* You have configured [Bitbucket notifications (webhooks)]({{< ref "docs/setup/other_config/features/notifications/index.md#bitbucket-cloud" >}}) in Spinnaker and enabled the desired webhook events in your Bitbucket repository.
+
+## Add a Bitbucket webhook event as a pipeline trigger
+
+1. In your pipeline, go to **Configuration** > **Automated Triggers**.
+1. Configure a new trigger with the following information:
+
+   * **Type**: `Git`
+   * **Repo Type**: `bitbucket`
+   * **Team or User**: enter your Bitbucket team or user name
+   * **Repo name**: enter your Bitbucket repo name
+   * **Branch**: enter your branch name (optional)
+   * **Artifact Constraints**: select a constraint (optional)
+   * **Trigger Enabled**: select the box
+
+## Troubleshooting
+
+Check the Echo log for webhook activity.

--- a/content/en/docs/guides/user/pipeline/triggers/gcs/_index.md
+++ b/content/en/docs/guides/user/pipeline/triggers/gcs/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Receiving artifacts from GCS"
 linkTitle: "GCS"
-weight:
 description: >
   Configure Spinnaker to trigger pipelines based on changes in a [Google Cloud Storage](https://cloud.google.com/storage/) (GCS) bucket and inject changed GCS objects as [artifacts](/docs/reference/artifacts) into a pipeline.
 ---
@@ -78,7 +77,7 @@ Next, we must configure the trigger:
 
 | Field | Value |
 |-------|-------|
-| __Type__ | "Pub/Sub" | 
+| __Type__ | "Pub/Sub" |
 | __Pub/Sub System Type__ | "Google" |
 | __Subscription Name__  | Depends on your Pub/Sub configuration (from Halyard|
 | __Attribute Constraints__ | Must be configured to include the pair `eventType`:`OBJECT_FINALIZE` (See the [docs](https://cloud.google.com/storage/docs/pubsub-notifications#events)) |

--- a/content/en/docs/guides/user/pipeline/triggers/github/_index.md
+++ b/content/en/docs/guides/user/pipeline/triggers/github/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Receiving artifacts from GitHub"
 linkTitle: "GitHub"
-weight:
 description: >
   Trigger pipelines based on commits to a [GitHub](https://github.com)
   repository, and inject changed GitHub files as

--- a/content/en/docs/guides/user/pipeline/triggers/jenkins/_index.md
+++ b/content/en/docs/guides/user/pipeline/triggers/jenkins/_index.md
@@ -1,7 +1,6 @@
 ﻿---
 title: "Triggering pipelines with Jenkins"
 linkTitle: "Jenkins"
-weight:
 description: >
   Add a [Jenkins](https://jenkins.io/) trigger to your pipeline.
 ---
@@ -75,5 +74,5 @@ Finally to add the Jenkins build artifact as a Spinnaker artifact, do the follow
  3. Add a new HTTP file artifact to the pipeline replacing the build number with the BUILD field from the properties using the following variable - ``${trigger.properties['BUILD']}`` like this
 
  ![Manifest Configuration](https://github.com/dniasoff/spinnaker.io/raw/master/content/en/docs/guides/user/pipeline/triggers/jenkins/manifest-configuration.png)
- 
+
 

--- a/content/en/docs/guides/user/pipeline/triggers/pubsub/_index.md
+++ b/content/en/docs/guides/user/pipeline/triggers/pubsub/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Triggering on Pub/Sub Messages"
 linkTitle: "Pub/Sub Messages"
-weight:
 description: >
   Trigger pipelines from Pub/Sub messages.
 ---
@@ -15,7 +14,7 @@ Pipeline's execution.
 > **Note**:  It's possible to configure multiple pipelines to trigger off of
 > a single Pub/Sub message.
 
-Only Google and AWS Pub/Sub systems are supported. See the detailed instructions for 
+Only Google and AWS Pub/Sub systems are supported. See the detailed instructions for
 [Google Pub/Sub](/docs/setup/other_config/triggers/google/) and [AWS SQS/SNS](/docs/setup/other_config/triggers/amazon/).
 
 ## Prerequisites

--- a/content/en/docs/guides/user/pipeline/triggers/webhooks/_index.md
+++ b/content/en/docs/guides/user/pipeline/triggers/webhooks/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Triggering on Webhooks"
 linkTitle: "Webhooks"
-weight:
 description: >
   Use a webhook to trigger a pipeline.
 ---
@@ -19,8 +18,8 @@ you, will be available in the Pipeline's execution.
 If you're triggering from a *GitHub* webhook, see the instructions
 [here](/docs/setup/other_config/triggers/github/) to set up that webhook.
 
-If you're triggering to a Spinnaker with authentication, see the 
-instructions [here](/docs/setup/other_config/security/authorization/#automated-pipeline-triggers) to set up the 
+If you're triggering to a Spinnaker with authentication, see the
+instructions [here](/docs/setup/other_config/security/authorization/#automated-pipeline-triggers) to set up the
 automated trigger.
 
 ## Prerequisites


### PR DESCRIPTION
Scheduled for v1.30
- Code PR https://github.com/spinnaker/echo/pull/1219
- Removed `weight` front matter variable from pages in this section since weight had no value set; no weight == sort alphabetically
- Add new Bitbucket webhook events and how to use them as automated triggers in a pipeline

Fixes: https://github.com/spinnaker/spinnaker.io/issues/284

Deploy preview:  https://deploy-preview-285--spinnaker-io.netlify.app/docs/guides/user/pipeline/triggers/bitbucket-events/