### PR TITLE
docs(kork): Update the next release preview changelog

### DIFF
--- a/content/en/docs/releases/next-release-preview/index.md
+++ b/content/en/docs/releases/next-release-preview/index.md
@@ -46,15 +46,19 @@ that this SpEL should be evaluated by a different tool. No exceptions are thrown
 ${#toJson(#doNotEval(fileMap))}
 ```
 
-Use a feature flag to enable.
+The feature flag introduced in Kork (1.28/29 releases) to use `doNotEval` SPeL expression helper will be enabled by default.
 
-```yaml
-# orca-local.yml
+- This feature is disabled only when the flag is set explicitly to false.
 
-expression:
-  do-not-eval-spel:
-    enabled: true
-```
+  ```yaml
+    # orca-local.yml
+  
+  expression:
+    do-not-eval-spel:
+    enabled: false
+  ```
+See the changes [here](https://github.com/spinnaker/kork/pull/1028)
+
 ### Artifact handling
 
 #### Changes to the way artifact constraints on triggers work

--- a/content/en/docs/releases/next-release-preview/index.md
+++ b/content/en/docs/releases/next-release-preview/index.md
@@ -46,8 +46,9 @@ that this SpEL should be evaluated by a different tool. No exceptions are thrown
 ${#toJson(#doNotEval(fileMap))}
 ```
 
-The feature flag introduced in Kork (1.28/29 releases) to use `doNotEval` SPeL expression helper will be enabled by default.
-
+This feature introduces a new SpEL `doNotEval` method that includes the received JSON object with the NotEvaluableExpression class. 
+The toJson method (and others in the future) will not evaluate expressions and will not throw exceptions for instances of the NotEvaluableExpression class.
+- The feature flag introduced in Kork (1.28/29 releases) to use `doNotEval` SPeL expression helper will be enabled by default.
 - This feature is disabled only when the flag is set explicitly to false.
 
   ```yaml
@@ -55,7 +56,7 @@ The feature flag introduced in Kork (1.28/29 releases) to use `doNotEval` SPeL e
   
   expression:
     do-not-eval-spel:
-    enabled: false
+      enabled: false
   ```
 See the changes [here](https://github.com/spinnaker/kork/pull/1028)
 

--- a/content/en/docs/releases/next-release-preview/index.md
+++ b/content/en/docs/releases/next-release-preview/index.md
@@ -58,7 +58,7 @@ The toJson method (and others in the future) will not evaluate expressions and w
     do-not-eval-spel:
       enabled: false
   ```
-See the changes [here](https://github.com/spinnaker/kork/pull/1028)
+See the changes [here](https://github.com/spinnaker/kork/pull/978)
 
 ### Artifact handling
 


### PR DESCRIPTION
Update the next release changelog with the changes done to enable by default the "doNotEval SPeL expression" feature flag