### PR TITLE
docs(changelog): document front50 config flags for optimizing cache refresh

### DIFF
--- a/content/en/docs/releases/next-release-preview/index.md
+++ b/content/en/docs/releases/next-release-preview/index.md
@@ -14,3 +14,22 @@ changelog.
 ### [doNotEval SpEL helper](https://spinnaker.io/changelogs/1.30.0-changelog/#donoteval-spel-helper)
 This feature is now enabled by default
 
+### Front50
+
+https://github.com/spinnaker/front50/pull/1249 adds three new configuration flags for [each object type under service-storage](https://github.com/spinnaker/front50/blob/568743732dcb47cc576a178795b6a992923f1d3c/front50-core/src/main/java/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.java#L8).
+
+* storage-service.*.cacheHealthCheckTimeoutSeconds: The cache is considered healthy if it's been refreshed in `cacheHealthCheckTimeoutSeconds` seconds.  The default is 90.
+
+* storage-service.*.synchronizeCacheRefresh: When true, if multiple threads attempt to refresh the cache in StorageServiceSupport simultaneously, only one actually does the refresh. The others wait until it's complete. This reduces load on the data store.  The default is false.
+
+* storage-service.*.optimizeCacheRefreshes: Only implemented for sql data stores.  When true, for objects that support versioning, cache refreshes only query the data store for objects modified (or deleted) since the last refresh.  The default is false.
+
+`synchronizeCacheRefresh` and `optimizeCacheRefreshes` improve the performance of keeping front50's in-memory cache up to date.  Here's an example of setting them to true for both applications and pipelines.
+
+    storage-service:
+      application:
+        optimizeCacheRefreshes: true
+        synchronizeCacheRefresh: true
+      pipeline:
+        optimizeCacheRefreshes: true
+        synchronizeCacheRefresh: true


### PR DESCRIPTION
document changes from https://github.com/spinnaker/front50/pull/1249