### PR TITLE
Added latest helm chart, Removed unsupported operator

### DIFF
--- a/content/en/docs/setup/quickstart.md
+++ b/content/en/docs/setup/quickstart.md
@@ -12,8 +12,8 @@ If you want to install Spinnaker on Lightweight Kubernetes (K3s) for proofs of c
 
 Options for installing Spinnaker in Kubernetes:
 
+- [Spinnaker Helm Chart](https://github.com/OpsMx/spinnaker-helm) is an open source helm chart to install/configure spinnaker in GitOps/Non-GitOps style
 - [Spinnaker Operator for Kubernetes](https://github.com/armory/spinnaker-operator) is an open source Kubernetes Operator for deploying and managing Spinnaker. You can install a basic version of Spinnaker or use Kustomize files for advanced configuration.
-- [Spinnaker Operator](https://operatorhub.io/operator/spinnaker-operator) is an open source Helm chart for installing Spinnaker.
 - [Kubernetes Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/spinnaker) **As of Nov 13, 2020, charts in this repo are no longer updated. **
 
 Guides for installing Spinnaker in specific cloud environments:


### PR DESCRIPTION
1. Added - [Spinnaker Helm Chart](https://github.com/OpsMx/spinnaker-helm) is an open source helm chart to install/configure spinnaker in GitOps/Non-GitOps style
2. Removed "- [Spinnaker Operator](https://operatorhub.io/operator/spinnaker-operator) is an open source Helm chart for installing Spinnaker. " as this is no longer supported by OpsMx