### PR TITLE
chore(analytics): google analytics update

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -47,7 +47,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-70174036-1"
+id = "G-H0XE7ESBFR"
 
 # Language configuration
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,7 +14,7 @@
   {{- template "_internal/schema.html" . -}}
   {{- template "_internal/twitter_cards.html" . -}}
   {{ if eq (getenv "HUGO_ENV") "production" }}
-  {{ template "_internal/google_analytics_async.html" . }}
+  {{ template "_internal/google_analytics.html" . }}
   {{ end }}
   {{ partialCached "head-css.html" . "asdf" }}
 <script


### PR DESCRIPTION
[Google Analytics 4](https://support.google.com/analytics/answer/10089681?hl=en) is out and the previous solution, Google Universal Analytics, will no longer process data on July 1, 2023. 
Since we use Hugo, I took a look at the [official documentation for google analytics templates](https://gohugo.io/templates/internal/#use-the-google-analytics-template) and [community discussion about Google Analytics 4 upgrade](https://discourse.gohugo.io/t/how-to-make-site-updates-to-support-google-analytics-4/38271/4). 

I've migrated our GA to support both the old and new tag methods, so once this is merged, we should be able to see traffic in the new GA property.

Note: I have not tested this, would appreciate another set of eyes 🙏 