### PR TITLE
Update release cadence docs to reference the google group in addition to the google calendar.

### DIFF
--- a/content/en/docs/releases/release-cadence/index.md
+++ b/content/en/docs/releases/release-cadence/index.md
@@ -74,3 +74,5 @@ There's a public calendar you can subscribe to which includes important release 
 * If you don't want to subscribe directly, you can check the calendar below:
 
 <iframe src="https://calendar.google.com/calendar/embed?src=spinnaker.io_p2n8segvlnel4cbo777em35b0c%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+Alternatively, join the [spinnaker-announce](https://groups.google.com/forum/#!forum/spinnaker-announce) Google Group (requires a Google account) or the [spinnaker-releases](https://app.slack.com/client/T091CRSGH/CHD4ATAMV) Slack channel for updates.


### PR DESCRIPTION
It appears that the google calendar is no longer updated in favor of the google group, so this documentation needs updating as it is easy to miss the small alert on the versions page, subscribe to the calendar and then never receive notifications.