### PR TITLE
Make Custom Job output docs clearer.

### DIFF
--- a/content/en/docs/guides/operator/custom-job-stages/index.md
+++ b/content/en/docs/guides/operator/custom-job-stages/index.md
@@ -45,7 +45,7 @@ The following properties are supported for the `kubernetes` cloud provider.
 * `account` - Account name used when executing the job. Must be valid account for `cloudProvider`.
 * `application` - Name of the application to associate the job with.
 * `manifest` - YAML definition for the [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) that will be run when the stage is executed.
-* `propertyFile` - Use logs from this container to capture output data. Captured output will be available in the pipeline context for use in downstream stages.
+* `propertyFile` - The container name to [capture output data](/docs/guides/user/kubernetes-v2/run-job-manifest#capturing-output) from. Captured output will be available in the pipeline context for use in downstream stages.
 
 _Note: If you're using the slash (`/`) character in any manifest annotations, you'll need to use this [special syntax](https://github.com/spring-projects/spring-boot/issues/13404#issuecomment-395307439) to prevent the slash from being dropped when the application reads its configuration. For example, if your annotation key is `iam.amazonaws.com/role` you'll need to define it like so: `[iam.amazonaws.com/role]`._
 


### PR DESCRIPTION
It took me a while to get output from a custom job step working because it wasn't clear to me that "this container" implied the value should be a container name as part of the kubernetes job. My inexperience with k8s is to blame but i feel the docs could've been more explicit to push me in the right direction sooner.

It also took me a while to find the docs specifying how to actually capture the output, a link to it would've saved me a fair bit of searching around.