### PR TITLE
fix(ga4): using tag instead of google analytics id

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -46,7 +46,7 @@ anchor = "smart"
 
 [services]
 [services.googleAnalytics]
-# Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
+# Comment out the id to disable the feature described in [params.ui.feedback].
 # This ID can be found in Google Analytics -> Admin Panel -> Data Streams -> Spinnaker Website - GA4 -> Measurement ID
 id = "G-H0XE7ESBFR"
 
@@ -95,6 +95,10 @@ defaultMarkdownHandler = "goldmark"
 copyright = 'Copyright © 2020 The Linux Foundation®. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. Linux is a registered trademark of Linus Torvalds.'
 privacy_policy = "http://www.linuxfoundation.org/privacy"
 terms_of_use = "http://www.linuxfoundation.org/terms"
+
+# Comment out the next line to disable GA tracking.
+# This Tag ID can be found in Google Analytics -> Admin Panel -> Data Streams -> Spinnaker Website - GA4 -> Configure Tag Settings
+google_tag_id="GT-W6BN9SN"
 
 # First one is picked as the Twitter card image if not set on page.
 # images = ["images/project-illustration.png"]

--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,0 +1,8 @@
+<!--This function is from tagmanager.google.com's installation instructions -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.google_tag_id }}"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', "{{ .Site.Params.google_tag_id }}");
+</script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,10 +13,17 @@
   {{- template "_internal/google_news.html" . -}}
   {{- template "_internal/schema.html" . -}}
   {{- template "_internal/twitter_cards.html" . -}}
-  {{ if eq (getenv "HUGO_ENV") "production" }}
-  {{ template "_internal/google_analytics.html" . }}
-  {{ end }}
   {{ partialCached "head-css.html" . "asdf" }}
+{{ if eq (getenv "HUGO_ENV") "production" }}
+<!--This function is from tagmanager.google.com's installation instructions -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.google_tag_id }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', "{{ .Site.Params.google_tag_id }}");
+</script>
+{{end}}
 <script
   src="https://code.jquery.com/jquery-3.3.1.min.js"
   integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,16 +14,6 @@
   {{- template "_internal/schema.html" . -}}
   {{- template "_internal/twitter_cards.html" . -}}
   {{ partialCached "head-css.html" . "asdf" }}
-{{ if eq (getenv "HUGO_ENV") "production" }}
-<!--This function is from tagmanager.google.com's installation instructions -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.google_tag_id }}"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', "{{ .Site.Params.google_tag_id }}");
-</script>
-{{end}}
 <script
   src="https://code.jquery.com/jquery-3.3.1.min.js"
   integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -8,3 +8,6 @@
   {{ $desc := (.Page.Content | safeHTML | truncate 150) }}
   <meta name="description" content="{{ $desc }}">
 {{ end }}
+{{ if eq (getenv "HUGO_ENV") "production" }}
+  {{ partial "google-analytics.html" . }}
+{{end}}


### PR DESCRIPTION
After the previous change related to google analytics, https://github.com/spinnaker/spinnaker.io/pull/346, I saw a drop in traffic. I reviewed spinnaker.io using google's provided tools, via https://tagmanager.google.com/, to scan the site for tags and it did not find any. I tested this locally and was able to see my traffic hit analytics.google.com 