### PR TITLE
doc(install-instruction) : Fixes powershell command by removing LF character which lead to Invoke-WebRequest cmdlet erroring out

### DIFF
--- a/content/en/docs/setup/other_config/spin/index.md
+++ b/content/en/docs/setup/other_config/spin/index.md
@@ -38,7 +38,7 @@ sudo mv spin /usr/local/bin/spin
 ```powershell
 New-Item -ItemType Directory $env:LOCALAPPDATA\spin -ErrorAction SilentlyContinue
 
-Invoke-WebRequest -OutFile $env:LOCALAPPDATA\spin\spin.exe -UseBasicParsing "https://storage.googleapis.com/spinnaker-artifacts/spin/$([System.Text.Encoding]::ASCII.GetString((Invoke-WebRequest https://storage.googleapis.com/spinnaker-artifacts/spin/latest).Content))/windows/amd64/spin.exe"
+Invoke-WebRequest -OutFile $env:LOCALAPPDATA\spin\spin.exe -UseBasicParsing "https://storage.googleapis.com/spinnaker-artifacts/spin/$([System.Text.Encoding]::ASCII.GetString((Invoke-WebRequest https://storage.googleapis.com/spinnaker-artifacts/spin/latest).Content) -replace "`n")/windows/amd64/spin.exe"
 
 Unblock-File $env:LOCALAPPDATA\spin\spin.exe
 


### PR DESCRIPTION

Existing PowerShell command for Windows throws error when running the **Invoke-WebRequest** cmdlet.

**Error :**

```
Invoke-WebRequest : InvalidObjectNameThe specified object name is not valid.Disallowed unicode characters present in object name 'spin/1.30.0
/windows/amd64/spin.exe'
At line:1 char:1
+ Invoke-WebRequest -OutFile $env:LOCALAPPDATA\spin\spin.exe -UseBasicP ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand
```

**Running a quick test :**

```
Write-Output "https://storage.googleapis.com/spinnaker-artifacts/spin/$((Invoke-WebRequest https://storage.googleapis.com/spinnaker-artifacts/spin/latest).Content)/windows/amd64/spin.exe"
```

**outputs :**

```
https://storage.googleapis.com/spinnaker-artifacts/spin/49 46 51 48 46 48 10/windows/amd64/spin.exe
```
which clearly points out the presence of an LF character.


Tested the code changes and working fine on **PowerShell Version** : **5.1.22621.2428**






    
    