### PR TITLE
Update index.md

### DIFF
--- a/content/en/docs/guides/user/kubernetes-v2/traffic-management/index.md
+++ b/content/en/docs/guides/user/kubernetes-v2/traffic-management/index.md
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: gcr.io/google_samples/gb-frontend:v3
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
 ```
 
 {{< figure src"create-sg.png" >}}
@@ -182,7 +182,7 @@ spec:
         app: myapp
     spec:
       containers:
-        - image: 'gcr.io/google_samples/gb-frontend:v3'
+        - image: 'us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5' 
           name: frontend
 ```
 


### PR DESCRIPTION
The container image gcr.io/google_samples/gb-frontend:v3 doesn't seem to work anymore so it can be replaced with us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5