### PR TITLE
Update 1.32.0-changelog.md to specify correct version of Halyard

### DIFF
--- a/content/en/changelogs/1.32.0-changelog.md
+++ b/content/en/changelogs/1.32.0-changelog.md
@@ -7,7 +7,7 @@ version: 1.32.0
 
 # Changelog
 
-**_Note: This release requires Halyard version 1.62.0 or later._**
+**_Note: This release requires Halyard version 1.42.0 or later._**
 
 This release includes fixes, features, and performance improvements across a wide feature set in Spinnaker. This section provides a summary of notable improvements followed by the comprehensive changelog.
 


### PR DESCRIPTION
1.62.0 isn't a version of halyard that is available currently (latest is 1.55.0), and spinnaker's 1.33.0 changelog specifies that 1.45.0 of halyard is necessary, so i assume this was a typo intended to be 1.42.0.