### PR TITLE
docs(pipeline expressions): Remove Code Inside Link

### DIFF
--- a/content/en/docs/reference/pipeline/expressions/_index.md
+++ b/content/en/docs/reference/pipeline/expressions/_index.md
@@ -75,7 +75,7 @@ pipeline.
 Note that `stages` is mostly referenced here for illustration purposes. The
 value of `stages[i]` depends on the order in which your stages execute, which
 makes it fragile. The recommended way to access a specific stage is to use the
-[`#stage("Stage Name")` helper function](#stagestring).
+`#stage("Stage Name")` [helper function](#stagestring).
 
 ### Maps
 


### PR DESCRIPTION
Description:
This commit addresses an issue where a code block is incorrectly nested inside a link in the pipeline expressions documentation. By removing the code block from inside the link, the rendering of the documentation is fixed.

Closes: #422 Docs Pipeline Expressions: Issue with Code Block Rendering