### PR TITLE
docs(changelog): pipelineCache.filterFront50Pipelines and front50.use…

### DIFF
--- a/content/en/docs/releases/next-release-preview/index.md
+++ b/content/en/docs/releases/next-release-preview/index.md
@@ -10,3 +10,11 @@ in the next release of Spinnaker. These notes will be prepended to the release
 changelog.
 
 ## Coming Soon in Release 1.35
+
+Version 1.31 of Spinnaker introduced two features that were disabled by default:
+
+[echo: pipelineCache.filterFront50Pipelines](https://spinnaker.io/changelogs/1.31.0-changelog/#echo)
+
+[orca: front50.useTriggeredByEndpoint](https://spinnaker.io/changelogs/1.31.0-changelog/#orca)
+
+Both of these features are now enabled by default.


### PR DESCRIPTION
…TriggeredByEndpoint are now enabled by default