### PR TITLE
doc(changelog): Spinnaker Version 1.33.0 changelog updated with broken functionality info

### DIFF
--- a/content/en/changelogs/1.33.0-changelog.md
+++ b/content/en/changelogs/1.33.0-changelog.md
@@ -7,10 +7,19 @@ version: 1.33.0
 
 # Changelog
 
+**_Note: Broken Functionality_**
+
+Spinnaker 1.33.0 upgrades to liquibase 4.24.0 which breaks the following scenarios when using postgres:
+* new installation with versions 1.33.0, 1.33.1, 1.34.0 & 1.34.1
+* upgrade/migration from versions < 1.33.0 to 1.33.0/1.33.1/1.33.2/1.34.0/1.34.1/1.34.2
+
+These scenarios work from [Spinnaker 1.33.3](https://spinnaker.io/changelogs/1.33.3-changelog/)(and above) and [Spinnaker 1.34.3](https://spinnaker.io/changelogs/1.34.3-changelog/)(and above).
+
+See https://github.com/spinnaker/spinnaker/issues/6941 and https://github.com/spinnaker/spinnaker/issues/6942 for more details.
+
 **_Note: This release requires Halyard version 1.45.0 or later._**
 
 This release includes fixes, features, and performance improvements across a wide feature set in Spinnaker. This section provides a summary of notable improvements followed by the comprehensive changelog.
-
 
 ### Lambda changes
 

--- a/content/en/changelogs/1.33.1-changelog.md
+++ b/content/en/changelogs/1.33.1-changelog.md
@@ -5,6 +5,16 @@ major_minor: 1.33
 version: 1.33.1
 ---
 
+**_Note: Broken Functionality_**
+
+Spinnaker 1.33.0 upgrades to liquibase 4.24.0 which breaks the following scenarios when using postgres:
+* new installation with versions 1.33.0, 1.33.1, 1.34.0 & 1.34.1
+* upgrade/migration from versions < 1.33.0 to 1.33.0/1.33.1/1.33.2/1.34.0/1.34.1/1.34.2
+
+These scenarios work from [Spinnaker 1.33.3](https://spinnaker.io/changelogs/1.33.3-changelog/)(and above) and [Spinnaker 1.34.3](https://spinnaker.io/changelogs/1.34.3-changelog/)(and above).
+
+See https://github.com/spinnaker/spinnaker/issues/6941 and https://github.com/spinnaker/spinnaker/issues/6942 for more details.
+
 ## [Clouddriver](#clouddriver) 5.83.1
 
 #### Fixes

--- a/content/en/changelogs/1.33.2-changelog.md
+++ b/content/en/changelogs/1.33.2-changelog.md
@@ -5,6 +5,16 @@ major_minor: 1.33
 version: 1.33.2
 ---
 
+**_Note: Broken Functionality_**
+
+Spinnaker 1.33.0 upgrades to liquibase 4.24.0 which breaks the following scenarios when using postgres:
+* new installation with versions 1.33.0, 1.33.1, 1.34.0 & 1.34.1
+* upgrade/migration from versions < 1.33.0 to 1.33.0/1.33.1/1.33.2/1.34.0/1.34.1/1.34.2
+
+These scenarios work from [Spinnaker 1.33.3](https://spinnaker.io/changelogs/1.33.3-changelog/)(and above) and [Spinnaker 1.34.3](https://spinnaker.io/changelogs/1.34.3-changelog/)(and above).
+
+See https://github.com/spinnaker/spinnaker/issues/6941 and https://github.com/spinnaker/spinnaker/issues/6942 for more details.
+
 ## [Clouddriver](#clouddriver) 5.83.2
 
 #### Fixes

--- a/content/en/changelogs/1.34.0-changelog.md
+++ b/content/en/changelogs/1.34.0-changelog.md
@@ -7,9 +7,20 @@ version: 1.34.0
 
 # Changelog
 
+**_Note: Broken Functionality_**
+
+Spinnaker 1.33.0 upgrades to liquibase 4.24.0 which breaks the following scenarios when using postgres:
+* new installation with versions 1.33.0, 1.33.1, 1.34.0 & 1.34.1
+* upgrade/migration from versions < 1.33.0 to 1.33.0/1.33.1/1.33.2/1.34.0/1.34.1/1.34.2
+
+These scenarios work from [Spinnaker 1.33.3](https://spinnaker.io/changelogs/1.33.3-changelog/)(and above) and [Spinnaker 1.34.3](https://spinnaker.io/changelogs/1.34.3-changelog/)(and above).
+
+See https://github.com/spinnaker/spinnaker/issues/6941 and https://github.com/spinnaker/spinnaker/issues/6942 for more details.
+
 **_Note: This release requires Halyard version 1.45.0 or later._**
 
 This release includes fixes, features, and performance improvements across a wide feature set in Spinnaker. This section provides a summary of notable improvements followed by the comprehensive changelog.
+
 
 
 https://github.com/spinnaker/orca/pull/4644 introduces a new feature to retry

--- a/content/en/changelogs/1.34.1-changelog.md
+++ b/content/en/changelogs/1.34.1-changelog.md
@@ -5,6 +5,16 @@ major_minor: 1.34
 version: 1.34.1
 ---
 
+**_Note: Broken Functionality_**
+
+Spinnaker 1.33.0 upgrades to liquibase 4.24.0 which breaks the following scenarios when using postgres:
+* new installation with versions 1.33.0, 1.33.1, 1.34.0 & 1.34.1
+* upgrade/migration from versions < 1.33.0 to 1.33.0/1.33.1/1.33.2/1.34.0/1.34.1/1.34.2
+
+These scenarios work from [Spinnaker 1.33.3](https://spinnaker.io/changelogs/1.33.3-changelog/)(and above) and [Spinnaker 1.34.3](https://spinnaker.io/changelogs/1.34.3-changelog/)(and above).
+
+See https://github.com/spinnaker/spinnaker/issues/6941 and https://github.com/spinnaker/spinnaker/issues/6942 for more details.
+
 ## [Clouddriver](#clouddriver) 5.85.1
 
 #### Other

--- a/content/en/changelogs/1.34.2-changelog.md
+++ b/content/en/changelogs/1.34.2-changelog.md
@@ -5,6 +5,16 @@ major_minor: 1.34
 version: 1.34.2
 ---
 
+**_Note: Broken Functionality_**
+
+Spinnaker 1.33.0 upgrades to liquibase 4.24.0 which breaks the following scenarios when using postgres:
+* new installation with versions 1.33.0, 1.33.1, 1.34.0 & 1.34.1
+* upgrade/migration from versions < 1.33.0 to 1.33.0/1.33.1/1.33.2/1.34.0/1.34.1/1.34.2
+
+These scenarios work from [Spinnaker 1.33.3](https://spinnaker.io/changelogs/1.33.3-changelog/)(and above) and [Spinnaker 1.34.3](https://spinnaker.io/changelogs/1.34.3-changelog/)(and above).
+
+See https://github.com/spinnaker/spinnaker/issues/6941 and https://github.com/spinnaker/spinnaker/issues/6942 for more details.
+
 ## [Clouddriver](#clouddriver) 5.85.2
 
 #### Fixes


### PR DESCRIPTION
With the liquibase 4.24.0 upgrade clouddriver and Orca were failing to start in some some scenarios. 
So updating the release notes with the details of broken functionality.