### PR TITLE
doc(changelog): Add changelog for upgrading all retrofit clients to retrofit2

### DIFF
--- a/content/en/docs/releases/next-release-preview/index.md
+++ b/content/en/docs/releases/next-release-preview/index.md
@@ -80,3 +80,11 @@ tasks:
       max-number-of-pipeline-executions-to-process:
       execution-retrieval-timeout-seconds:
 ```
+
+### retrofit2 upgrade
+
+All retrofit clients are upgraded to retrofit2 and any references to retrofit1 dependencies are removed in the following services.
+- Echo - https://github.com/spinnaker/echo/pull/1466
+- Fiat - https://github.com/spinnaker/fiat/pull/1195
+- Clouddriver - https://github.com/spinnaker/clouddriver/pull/6340 
+


### PR DESCRIPTION
Add changelog for the clouddriver PR - https://github.com/spinnaker/clouddriver/pull/6340 - refactor(retrofit2): replace retrofit client with retrofit2 client