### PR TITLE
Docs: Add ARM64 curl example

### DIFF
--- a/content/en/docs/setup/other_config/spin/index.md
+++ b/content/en/docs/setup/other_config/spin/index.md
@@ -26,6 +26,9 @@ sudo mv spin /usr/local/bin/spin
 ### On MacOS
 
 ```bash
+# Apple Silicon
+curl -LO https://storage.googleapis.com/spinnaker-artifacts/spin/$(curl -s https://storage.googleapis.com/spinnaker-artifacts/spin/latest)/darwin/arm64/spin
+# Intel
 curl -LO https://storage.googleapis.com/spinnaker-artifacts/spin/$(curl -s https://storage.googleapis.com/spinnaker-artifacts/spin/latest)/darwin/amd64/spin
 
 chmod +x spin


### PR DESCRIPTION
Add the `curl` command for ARM64, see https://github.com/spinnaker/spinnaker/issues/6632