### PR TITLE
doc(changelog): Add release note for igor retrofit2 upgrade

### DIFF
--- a/content/en/docs/releases/next-release-preview/index.md
+++ b/content/en/docs/releases/next-release-preview/index.md
@@ -10,3 +10,8 @@ in the next release of Spinnaker. These notes will be prepended to the release
 changelog.
 
 ## Coming Soon in Release 1.38
+
+### retrofit2 upgrade
+
+All retrofit clients are upgraded to retrofit2 and any references to retrofit1 dependencies are removed in the following services.
+- Igor - https://github.com/spinnaker/igor/pull/1313


### PR DESCRIPTION
Add release note for https://github.com/spinnaker/igor/pull/1313 which upgrades Igor to retrofit2 and removes all references and dependencies to retrofit1