### PR TITLE
fix(changelog): Fix patch versions sorting

### DIFF
--- a/layouts/shortcodes/deprecated-versions.html
+++ b/layouts/shortcodes/deprecated-versions.html
@@ -17,7 +17,7 @@ For example:
 
 <!-- add our latest major.minor to slice -->
 {{ range $grouped_changelogs }}
-{{ range first 1 (.Pages.ByParam "version").Reverse }}
+{{ range first 1 (.Pages.ByDate).Reverse }}
 {{ $latest_major_minors = $latest_major_minors | append .Page }}
 {{ end }}
 {{ end }}

--- a/layouts/shortcodes/latest-stable.html
+++ b/layouts/shortcodes/latest-stable.html
@@ -17,7 +17,7 @@ For example:
 
 <!-- add our latest major.minor to slice -->
 {{ range $grouped_changelogs }}
-{{ range first 1 (.Pages.ByParam "version").Reverse }}
+{{ range first 1 (.Pages.ByDate).Reverse }}
 {{ $latest_major_minors = $latest_major_minors | append .Page }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
I noticed version 1.39.10 is showing as deprecated while 1.39.9 is showing as latest.

This should fix it. I don't know if there is a case where an older version has a larger number (re-release?), but I doubt it.

Tested locally