### PR TITLE
fix(changelog): use numeric seconds in the timestamp for 2025.0.0

### DIFF
--- a/content/en/changelogs/2025.0.0-changelog.md
+++ b/content/en/changelogs/2025.0.0-changelog.md
@@ -1,6 +1,6 @@
 ---
 title: Spinnaker Release 2025.0.0
-date: 2025-04-19 02:04:SS +0000
+date: 2025-04-19 02:04:00 +0000
 major_minor: 2025.0
 version: 2025.0.0
 ---


### PR DESCRIPTION
so sorting works on https://spinnaker.io/docs/releases/versions/

https://github.com/spinnaker/spinnaker/pull/7047 has the fix for future releases.