### PR TITLE
doc(kayenta): update canary docs to mention that datadog supports filter templates

### DIFF
--- a/content/en/docs/guides/user/canary/config/canary-config.md
+++ b/content/en/docs/guides/user/canary/config/canary-config.md
@@ -156,7 +156,7 @@ aggregate the data.
 
 ### Add filter templates
 
-If your telemetry provider is Stackdriver or Prometheus, you can add [filter templates](/docs/guides/user/canary/config/filter-templates/) and then assign each
+If your telemetry provider is Stackdriver, Prometheus, or Datadog, you can add [filter templates](/docs/guides/user/canary/config/filter-templates/) and then assign each
 metric a filter template, if you want.
 
 1. Click __Add Template__.


### PR DESCRIPTION
Using filter templates in Kayenta canary analysis is now supported for Datadog.

Related PR: https://github.com/spinnaker/spinnaker/pull/7056