### PR TITLE
docs(release): add Spring Boot 3.0.13 upgrade notes and metrics export property changes

### DIFF
--- a/content/en/docs/releases/next-release-preview/index.md
+++ b/content/en/docs/releases/next-release-preview/index.md
@@ -36,5 +36,13 @@ to
 management.prometheus.metrics.export.*
 ```
 
+### Session data cleanup
+
+Spring Boot 3.0 considers session data cached by Spring Boot 2.7 invalid.  Therefore, users with cached sessions will be unable to log in until the invalid information is removed from the cache. Open browser windows to Spinnaker are unresponsive after the deployment until they’re reloaded.
+Executing:
+
+    $ redis-cli keys "spring:session*" | xargs redis-cli del
+
+on Gate's redis instance removes the cached session information.
 
 


### PR DESCRIPTION
**old schema:**
```
management:
  export:
    metrics:
      graphite:
        enabled: true
        host: localhost
        port: 2003
        protocol: pickled
        step: 1s
        graphite-tags-enabled: false
```

**new schema:**
```
management:
  graphite:
    metrics:
      export:
        enabled: true
        host: localhost
        port: ${embedded.graphite.picklePort}
        protocol: pickled
        step: 1s
        graphite-tags-enabled: false
```
Reference:
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#actuator-metrics-export-properties

depends-on: https://github.com/spinnaker/spinnaker/pull/7057