### PR TITLE
Enhance OAuth2 migration details in changelog

### DIFF
--- a/content/en/changelogs/2025.2.0-changelog.md
+++ b/content/en/changelogs/2025.2.0-changelog.md
@@ -17,7 +17,7 @@ https://github.com/spinnaker/spinnaker/pull/7240 changes constructors in AmazonC
 
 ##### Spring Security 5 Oauth2 Migration
 
-https://github.com/spinnaker/spinnaker/pull/7052 removes deprecated OAuth2 annotations, and uses Spring Security 5's DSL.  As a result, the properties for configuring oauth2 in gate have changed.
+https://github.com/spinnaker/spinnaker/pull/7052 removes deprecated OAuth2 annotations, and uses Spring Security 5's DSL. Various steps are required for this upgrade. The properties for configuring OAuth2 in Gate have changed:
 
 old:
 ```
@@ -95,6 +95,16 @@ halyard has been updated to generate the new configuration, with the same comman
 ```
 hal config security authn oauth2 edit --provider google --client-id some_id --client-secret some_secret --user-info-requirements hd=company.io
 ```
+
+Additionally, your OAuth2 resource needs to be updated to support the new redirect URI format. The previous format (`https://<your-domain>/login`) has changed to `https://<your-domain>/login/oauth2/code/<provider>`, where provider is one of `github`, `google`, or `other`. We recommend supporting both URL formats in your provider temporarily, to avoid issues in case of a need to rollback. 
+
+You will need to clear sessions in Redis after upgrading to avoid deserialization exceptions in Gate.
+
+```
+$ redis-cli keys "spring:session*" | xargs redis-cli del
+```
+
+Finally, `spin-cli` has been updated to support the new version. Post upgrade, users of `spin-cli` will need to download the latest version, and update their OAuth config by adding `provider` to their OAuth config block.
 
 ### Features
 


### PR DESCRIPTION
Updated the OAuth2 migration section with additional steps and configuration changes for Gate, including new redirect URI format and session clearing instructions.