### PR TITLE
chore(publishing): Note publishing change to GHCR for container images

### DIFF
--- a/content/en/docs/releases/next-release-preview/index.md
+++ b/content/en/docs/releases/next-release-preview/index.md
@@ -14,7 +14,7 @@ changelog.
 ### Images
 The spinnaker project will be moving docker images from Google's artifact registry to GHCR going forward.  This should save the project significantly on network and storage costs, while also allowing unlimited downloads.  As such
 we've started publishing all images to the [github packages pages](https://github.com/orgs/spinnaker/packages).  2025.6.0 should be the last release consuming images from google artifact registry.  Going forward, halyard
-and other images will start pulling from GHCR instead (incoming PRs shortly on this change).  Please update any whitelists, rules, and mirrors to start using GHCR as a package repository.  For more information, please join 
+and other images will start pulling from GHCR instead (incoming PRs shortly on this change).  Please update any allowlists, rules, and mirrors to start using GHCR as a package repository.  For more information, please join 
 slack and we'll answer any questions!
 
 ### Security fixes


### PR DESCRIPTION
Also call out this is likely the last release to CONSUME from GAR going forward.