### PR TITLE
Remove contrib_header from _index.md

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -12,7 +12,7 @@ news_text:
 news_link:
 
 join_slack_text: 'Join Spinnaker Slack, a place for the community to come together. Use this vibrant workspace to ask and answer questions, connect with other operators and users, discuss issues with SIGs, and learn about Spinnaker!'
-contrib_header: 'Need help? Book 30 minutes with a Spinnaker expert'
+contrib_header: 
 contrib_text:
 
 who_should_use_header: 'Who should use Spinnaker?'


### PR DESCRIPTION
# Main goal is to disable Calendly text

Removed the contribution header text from the index file. [calendly link is invalid now](https://calendly.com/d/28p-nnk-
gsw/spinnaker-office-hours-30-min-support-session)


> Need help? Book 30 minutes with a Spinnaker expert
>https://calendly.com/d/28p-nnk-gsw/spinnaker-office-hours-30-min-support-session 

