### PR TITLE
Remove Calendly button add office hours placeholder

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -123,12 +123,14 @@
     <h3 class="display-4 mr-3">{{.Params.contrib_header}}</h3>
   </div>
 
+<!-- Need Help row -->
   <div>
-    <a style="max-width: 235px; width: 100%;" class="btn btn-primary btn-lg mt-4"
-      href="https://calendly.com/d/28p-nnk-gsw/spinnaker-office-hours-30-min-support-session" target="_blank"
+    <!-- removed the Calendly functionality -->
+    <!-- <a style="max-width: 235px; width: 100%;" class="btn btn-primary btn-lg mt-4"
+      href="#" target="_blank"
       rel="noopener noreferrer" data-label="Book Support Call">
-      Book Support Call
-    </a>
+      Join office hours for questions! Coming Soon.
+    </a> -->
   </div>
 </div>
 


### PR DESCRIPTION
Removed the Calendly button and added a placeholder for office hours events.

comments the `<div>` with the button as below

<img width="384" height="358" alt="image" src="https://github.com/user-attachments/assets/64ede8b5-da2a-42d4-ab23-5174ddfa8957" />


* now is an empty area / placeholder

<img width="1883" height="611" alt="image" src="https://github.com/user-attachments/assets/3fef8fc7-9591-44de-9e83-c95ec1ee86f4" /> 
