### PR TITLE
feat(sidebar): Make the nav expand sub items

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -149,7 +149,10 @@ offlineSearch = true
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = true
+sidebar_menu_compact = false
+# Set to true to hide sub-items
+sidebar_menu_always_expand = true
+
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)


### PR DESCRIPTION
Proposing this - would make the nav when you hit "install"
<img width="1463" height="1362" alt="image" src="https://github.com/user-attachments/assets/e97fe7ca-7c91-424e-ac42-1b9f24b50dbb" />
Show the navigation windows.  I think this might make it a TOUCH easier to navigate the docs pages.