### PR TITLE
simplify install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ Open the URL printed in the terminal in your browser. Hugo rebuilds and reloads 
 4. Branches merged into `master` deploy to the live site.
 
 See [docs/website-contributing.md](docs/website-contributing.md) for content authoring, shortcodes, homepage config, and theme customization.
+
+## Recent Updates
+- Reorganized the installation documentation under `/docs/setup/install/` into clearer `Install` and `Configure` categories.

--- a/content/en/docs/setup/install/_index.md
+++ b/content/en/docs/setup/install/_index.md
@@ -10,7 +10,9 @@ This section describes how to install and set up Spinnaker.
 
 ---
 
-> Halyard is deprecated
+{{% alert color="warning" title="Important" %}}
+Halyard is deprecated.
+{{% /alert %}}
 
 # Halyard deprecation notice
 Halyard was previously mentioned on this page, and is deprecated in favor
@@ -23,7 +25,7 @@ a halyard or operator deployed spinnaker into kustomize style deployment.
 
 ---
 
-## What you'll need to install spinnaker
+## Requirements to install spinnaker
 
 * A kubernetes cluster
 

--- a/content/en/docs/setup/install/_index.md
+++ b/content/en/docs/setup/install/_index.md
@@ -8,12 +8,20 @@ description: >
 
 This section describes how to install and set up Spinnaker.
 
+---
+
+> Halyard is deprecated
+
 # Halyard deprecation notice
 Halyard was previously mentioned on this page, and is deprecated in favor
 of native installation using kustomize or similar native configurations.  References
 to halyard are being steadily removed from the project.  An
 [example script](/docs/setup/install/migration-to-kustomize-automation/) is available to export
 a halyard or operator deployed spinnaker into kustomize style deployment.
+
+> Halyard is deprecated
+
+---
 
 ## What you'll need to install spinnaker
 
@@ -30,12 +38,16 @@ You can also install [on a single local machine](https://www.spinnaker.io/setup/
 ## The process
 
 Installing a complete Spinnaker involves these steps:
-1. [Choose a cloud provider](/docs/setup/install/providers/)
-1. [Choose an installation method](/docs/setup/install/environment/)
-1. [Configure a database for storage](/docs/setup/install/storage/)
-1. [Deploy Spinnaker](/docs/setup/install/deploy/)
-1. [Configure everything else](/docs/setup/other_config/) 
-1. [Productionize Spinnaker](/docs/setup/productionize/)
+
+### Install spinnaker
+* [Choose an installation method](/docs/setup/install/environment/)
+* [Deploy Spinnaker](/docs/setup/install/deploy/)
+
+### Configure spinnaker
+* [Choose a cloud provider](/docs/setup/install/providers/)
+* [Configure a database for storage](/docs/setup/install/storage/)
+* [Configure everything else](/docs/setup/other_config/)
+* [Productionize Spinnaker](/docs/setup/productionize/)
 
 It is HIGHLY recommended to at LEAST setup authentication for spinnaker!
 

--- a/content/en/docs/setup/install/deploy.md
+++ b/content/en/docs/setup/install/deploy.md
@@ -1,8 +1,8 @@
 ---
 
-title:  "Deploy Spinnaker and Connect to the UI"
-description: After you finish configuring Spinnaker, deploy it and connect to the Deck, the Spinnaker UI.
-weight: 50
+title:  "Deploy Spinnaker and Connect"
+description: After you finish configuring Spinnaker, deploy it and connect to the Spinnaker UI (Deck).
+weight: 20
 ---
 
 Now that we've enabled one or more [Cloud Providers](/docs/setup/install/providers/), picked a [Deployment Environment](/docs/setup/install/environment/), and configured
@@ -17,34 +17,36 @@ Now that we've enabled one or more [Cloud Providers](/docs/setup/install/provide
 
 1. Set the version you want to use:
 Set this on the [kustomize image tag configuration](https://github.com/spinnaker/spinnaker/blob/main/spinnaker-kustomize/kustomization.yml#L12C15-L12C16).  All spinnaker versions since
-the monorepo use the same image tags, e.g. 2025.3.2.  
+the monorepo use the same image tags, e.g. 2025.3.2.
 
 ## Deploy Spinnaker
 
 ```bash
 kubectl kustomize -o ./spinnaker.yaml
 kubectl apply -f ./spinnaker.yaml
-
 ```
 
 ## Ingress
 
 A default ingress is included that uses a single ingress with path based routes to gate's API
 on a prefix.  This bypasses CORS issues and enables a simple user experience to connect
-to spinnaker.  The default username and passwords are also set in this installation.  For
-ingress specific to your environment, please adjust [the default ingress](https://github.com/spinnaker/spinnaker/blob/main/spinnaker-kustomize/ingress.yaml) 
+to spinnaker. The default username and passwords are also set in this installation. 
+
+For ingress specific to your environment, please adjust [the default ingress](https://github.com/spinnaker/spinnaker/blob/main/spinnaker-kustomize/ingress.yaml)
 as needed for your use case.
 
 ## Connect to the Spinnaker UI
 Once deployed, get the address for your ingress controller and connect to the ingress.  Make
 sure you have a domain address pointing to your new endpoint.  Example:
-```
-k get ingress -n spinnaker
+
+```bash
+kubectl get ingress --namespace spinnaker
+
 NAME                CLASS   HOSTS                     ADDRESS          PORTS     AGE
 spinnaker-ingress   nginx   spinnaker.example.com     192.168.1.2      80, 443   644d
 ```
 This ingress would include 443 or TLS as configured.  It's recommended to enable a 
-cert provider and use HTTPS for requests but this is out of the scope of the installation.  
+cert provider and use HTTPS for requests but this is out of the scope of the installation.
 See the [kubernetes networking documentation on TLS](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) 
 for information on modifying the ingress for certificate handling.
 
@@ -54,7 +56,7 @@ that you've configured (or your SSO provider if so configured [per authenticatio
 
 ## Troubleshooting
 First, check that services are running.  IF a service isn't running, check the logs
-for configuration errors.  
+for configuration errors. 
 
 Next once all services are running, make sure you can talk to the gate endpoint.  You
 should be able to check the health endpoint even externally via the gate-api/health endpoint.

--- a/content/en/docs/setup/install/environment.md
+++ b/content/en/docs/setup/install/environment.md
@@ -2,7 +2,7 @@
 
 title:  "Choose your Environment"
 description: Based on your use case, choose how you want to install Spinnaker.
-weight: 30
+weight: 10
 ---
 
 In this step, you choose where to install Spinnaker. The recommended path is an installation into a
@@ -99,6 +99,4 @@ Ensure that the following are installed on your system:
   of the Distributed installation.
 
 ## Next steps
-
-Now that your deployment environment is set up, you need to provide Spinnaker
-with a [Persistent Storage](/docs/setup/install/storage/) source.
+After you've set up your external storage service, you're ready to [deploy Spinnaker](/docs/setup/install/deploy/).

--- a/content/en/docs/setup/install/providers/_index.md
+++ b/content/en/docs/setup/install/providers/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Cloud Providers Overview"
 linkTitle: "Choose Cloud Providers"
-weight: 10
+weight: 30
 description: In Spinnaker, providers are integrations to the Cloud platforms you deploy your applications to.
 aliases:
   - /docs/target-deployment-setup

--- a/content/en/docs/setup/install/storage.md
+++ b/content/en/docs/setup/install/storage.md
@@ -64,4 +64,7 @@ The default spinnaker-kustomize installation uses a [component to auto inject](h
 into the targeted services.  
 
 ## Next steps
-After you've set up your external storage service, you're ready to [deploy Spinnaker](/docs/setup/install/deploy/).
+
+Now that your deployment environment is set up, , you can…
+
+* [Configure everything else](/docs/setup/other_config/)


### PR DESCRIPTION
1. simplifies the structure of the install now that kustomize is very stable
2. structure is now split into install and configure
3. re-orders the pages by giving different weights

<img width="1099" height="943" alt="image" src="https://github.com/user-attachments/assets/4da03cf6-3e6f-4874-8dfe-c130d0e5e343" />
