### PR TITLE
fix(blog): fix blog references to go direct to the medium page

### DIFF
--- a/content/en/docs/community/contributing/code/developer-guides/extending/crd-extensions.md
+++ b/content/en/docs/community/contributing/code/developer-guides/extending/crd-extensions.md
@@ -23,7 +23,7 @@ It also exists as an explanation of certain code paths within Spinnaker which in
 
 Developers who want to implement these features will have to build their own layered version
 of Clouddriver [(found in the monorepo)](https://github.com/spinnaker/spinnaker) -
-  see Adam Jorden's [blog post](https://blog.spinnaker.io/scaling-spinnaker-at-netflix-custom-features-and-packaging-e78536d38040) - and should be familiar with the [Kubernetes provider](/docs/reference/providers/kubernetes) and writing code for Clouddriver.
+  see Adam Jorden's [blog post](https://medium.com/continuous-delivery-scale/scaling-spinnaker-at-netflix-custom-features-and-packaging-e78536d38040) - and should be familiar with the [Kubernetes provider](/docs/reference/providers/kubernetes) and writing code for Clouddriver.
 
 ## Custom Handlers
 

--- a/content/en/docs/community/contributing/content-contributing.md
+++ b/content/en/docs/community/contributing/content-contributing.md
@@ -3,7 +3,7 @@ title: Getting Started as a Content Contributor
 weight: 3
 ---
 
-[Originally published on the Spinnaker Community Blog](https://blog.spinnaker.io/getting-started-as-a-content-contributor-fd4d3bde420a)
+[Originally published on the Spinnaker Community Blog](https://medium.com/continuous-delivery-scale/getting-started-as-a-content-contributor-fd4d3bde420a)
 
 Hi! Nikema here. I co-lead the Spinnaker Contributor Experience Special Interest Group (SIG) with Adetokunbo Ige. Since stepping into this role, I’ve wanted to write a post to explicitly welcome non-code contributions to the project. This is meant to be a living document, and I am open to feedback and suggestions. Let’s work together to make open source contributing a little less intimidating.
 

--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -128,7 +128,7 @@ diverge from the desired state, and acts upon that information to reconcile the 
 desired state.
 
 For more details on the inspiration and guiding principles behind
-Managed Delivery, check out [our blog](https://blog.spinnaker.io/managed-delivery-evolving-continuous-delivery-at-netflix-eb74877fb33c),
+Managed Delivery, check out [our blog](https://medium.com/continuous-delivery-scale/managed-delivery-evolving-continuous-delivery-at-netflix-eb74877fb33c),
 or the talk below from Spinnaker Summit 2019.
 
 <iframe src="https://www.youtube.com/embed/mEgvOfmLnlY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/content/en/docs/guides/developer/extending/crd-extensions.md
+++ b/content/en/docs/guides/developer/extending/crd-extensions.md
@@ -21,7 +21,7 @@ It also exists as an explanation of certain code paths within Spinnaker which in
 
 Developers who want to implement these features will have to build their own layered version
 of [Clouddriver](https://github.com/spinnaker/clouddriver) -
-  see Adam Jorden's [blog post](https://blog.spinnaker.io/scaling-spinnaker-at-netflix-custom-features-and-packaging-e78536d38040) - and should be familiar with the [Kubernetes provider](/reference/providers/kubernetes) and writing code for Clouddriver.
+  see Adam Jorden's [blog post](https://medium.com/continuous-delivery-scale/scaling-spinnaker-at-netflix-custom-features-and-packaging-e78536d38040) - and should be familiar with the [Kubernetes provider](/reference/providers/kubernetes) and writing code for Clouddriver.
 
 ## Custom Handlers
 

--- a/content/en/docs/guides/tutorials/codelabs/safe-deployments/index.md
+++ b/content/en/docs/guides/tutorials/codelabs/safe-deployments/index.md
@@ -279,4 +279,4 @@ The child pipeline should not run
 
 ## Learn more
 
-Hopefully this codelab has given you a taste of the built-in mechanisms for safe deployment in Spinnaker. An almost complete list of safe deployment features in Spinnaker can be found in this [blog post](https://blog.spinnaker.io/can-i-push-that-building-safer-low-risk-deployments-with-spinnaker-a27290847ac4).
+Hopefully this codelab has given you a taste of the built-in mechanisms for safe deployment in Spinnaker. An almost complete list of safe deployment features in Spinnaker can be found in this [blog post](https://medium.com/continuous-delivery-scale/can-i-push-that-building-safer-low-risk-deployments-with-spinnaker-a27290847ac4).

--- a/content/en/docs/guides/user/kubernetes/best-practices/index.md
+++ b/content/en/docs/guides/user/kubernetes/best-practices/index.md
@@ -39,7 +39,7 @@ There are two ways to achieve this in Spinnaker:
 To keep track of what's changing in your cluster, and under what circumstances
 it is changing, we highly recommend [configuring Spinnaker to emit events to an
 external audit
-log](https://blog.spinnaker.io/spinnaker-echo-google-cloud-functions-stackdriver-logging-spinnaker-audit-log-81139f084db9).
+log](https://medium.com/continuous-delivery-scale/spinnaker-echo-google-cloud-functions-stackdriver-logging-spinnaker-audit-log-81139f084db9).
 
 Spinnaker already generates events for any events running through its
 orchestration engine, all that's needed is an endpoint to send them to.  When

--- a/content/en/docs/guides/user/kubernetes/run-job-manifest/index.md
+++ b/content/en/docs/guides/user/kubernetes/run-job-manifest/index.md
@@ -7,7 +7,7 @@ description: >
 
 The `Run Job (Manifest)` stage can be used to execute a Kubernetes Job as part of your pipeline. This stage will deploy a `Job` manifest and wait until it completes, allowing you to gate your pipeline's continuation on the job's success or failure.
 
-For example use cases, check out [this post](https://blog.spinnaker.io/extending-spinnaker-with-kubernetes-and-containers-5d16ec810d81) on the Spinnaker blog!
+For example use cases, check out [this post](https://medium.com/continuous-delivery-scale/extending-spinnaker-with-kubernetes-and-containers-5d16ec810d81) on the Spinnaker blog!
 
 ## Viewing execution logs
 

--- a/content/en/docs/reference/halyard/high-availability.md
+++ b/content/en/docs/reference/halyard/high-availability.md
@@ -17,7 +17,7 @@ description:
 
 
 
-This page describes how you can configure a Halyard deployment to increase the availability of specific services beyond simply [horizontally scaling](/docs/setup/productionize/scaling/horizontal-scaling/) the service. Halyard does this by splitting the functionalities of a service into separate logical roles (also known as sharding). The benefits of doing this is specific to the service that is being sharded. These deployment strategies are inspired by [Netflix's large scale experience](https://blog.spinnaker.io/scaling-spinnaker-at-netflix-part-1-8a5ae51ee6de).
+This page describes how you can configure a Halyard deployment to increase the availability of specific services beyond simply [horizontally scaling](/docs/setup/productionize/scaling/horizontal-scaling/) the service. Halyard does this by splitting the functionalities of a service into separate logical roles (also known as sharding). The benefits of doing this is specific to the service that is being sharded. These deployment strategies are inspired by [Netflix's large scale experience](https://medium.com/continuous-delivery-scale/scaling-spinnaker-at-netflix-part-1-8a5ae51ee6de).
 
 When sharded, the new logical services are given new names. This means that these logical services can be configured and scaled independently of each other.
 
@@ -192,4 +192,4 @@ If you've [configured an external Redis](/docs/setup/productionize/caching/exter
 
 Although it's possible, it is not recommended to use spot instances on AWS or preemtible nodes to lower cost in production, as outages in your continuous deployment tool will likely cost more than any savings. Also consider hosting Spinnaker on isolated infrastructure to reduce the possibility that other applications or teams will affect your Spinnaker instance.
 
-It's also recommended to spread out services over multiple availability zones, as described in [the Netflix implementation](https://blog.spinnaker.io/scaling-spinnaker-at-netflix-part-1-8a5ae51ee6de).
+It's also recommended to spread out services over multiple availability zones, as described in [the Netflix implementation](https://medium.com/continuous-delivery-scale/scaling-spinnaker-at-netflix-part-1-8a5ae51ee6de).

--- a/content/en/docs/reference/providers/ecs.md
+++ b/content/en/docs/reference/providers/ecs.md
@@ -105,7 +105,7 @@ Spinnaker.
 
   These provide ways to group resources using Spinnaker's cluster filters
   as well as apply policies such as [Traffic
-  Guards](https://blog.spinnaker.io/can-i-push-that-building-safer-low-risk-deployments-with-spinnaker-a27290847ac4).
+  Guards](https://medium.com/continuous-delivery-scale/can-i-push-that-building-safer-low-risk-deployments-with-spinnaker-a27290847ac4).
 
 * `moniker.spinnaker.io/sequence` 📝
 

--- a/content/en/docs/reference/providers/kubernetes/index.md
+++ b/content/en/docs/reference/providers/kubernetes/index.md
@@ -109,7 +109,7 @@ command](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands
 
   These simply provide ways to group resources using Spinnaker's cluster filters
   as well as apply policies such as [Traffic
-  Guards](https://blog.spinnaker.io/can-i-push-that-building-safer-low-risk-deployments-with-spinnaker-a27290847ac4).
+  Guards](https://medium.com/continuous-delivery-scale/can-i-push-that-building-safer-low-risk-deployments-with-spinnaker-a27290847ac4).
 
 ## Caching
 

--- a/content/en/docs/setup/install/faq.md
+++ b/content/en/docs/setup/install/faq.md
@@ -58,7 +58,7 @@ two solutions.
    and `hal config security api edit --override-base-url <full api url>`.
 
 2. If you don't want to rely on authentication, you can follow [this
-   guide](https://blog.spinnaker.io/exposing-spinnaker-to-end-users-4808bc936698).
+   guide](https://medium.com/continuous-delivery-scale/exposing-spinnaker-to-end-users-4808bc936698).
    This makes sense if you're running Spinnaker in a private network, or have
    another form of authentication fronting Spinnaker.
 

--- a/content/en/docs/setup/install/high-availability.md
+++ b/content/en/docs/setup/install/high-availability.md
@@ -12,7 +12,7 @@ of specific services beyond simply [horizontally scaling](/docs/setup/production
 
 This is done by splitting the functionalities of a service into separate logical roles. The benefits of
 doing this is specific to the service that is being sharded. These deployment strategies are inspired
-by [Netflix's large scale experience](https://blog.spinnaker.io/scaling-spinnaker-at-netflix-part-1-8a5ae51ee6de).
+by [Netflix's large scale experience](https://medium.com/continuous-delivery-scale/scaling-spinnaker-at-netflix-part-1-8a5ae51ee6de).
 
 When sharded, the new logical services are given new names. This means that these logical services can be configured and scaled independently of each other.
 
@@ -166,4 +166,4 @@ If you've [configured an external Redis](/docs/setup/productionize/caching/exter
 
 Although it's possible, it is not recommended to use spot instances on AWS or preemtible nodes to lower cost in production, as outages in your continuous deployment tool will likely cost more than any savings. Also consider hosting Spinnaker on isolated infrastructure to reduce the possibility that other applications or teams will affect your Spinnaker instance.
 
-It's also recommended to spread out services over multiple availability zones, as described in [the Netflix implementation](https://blog.spinnaker.io/scaling-spinnaker-at-netflix-part-1-8a5ae51ee6de).
+It's also recommended to spread out services over multiple availability zones, as described in [the Netflix implementation](https://medium.com/continuous-delivery-scale/scaling-spinnaker-at-netflix-part-1-8a5ae51ee6de).

--- a/content/en/docs/setup/other_config/monitoring/_index.md
+++ b/content/en/docs/setup/other_config/monitoring/_index.md
@@ -38,7 +38,7 @@ underlying metric stores depending on your situation.
 
 
 To read more about the spinnaker monitoring daemon deprecation, check out the
-[announcement](https://blog.spinnaker.io/announcing-the-new-spinnaker-observability-plugin-d7fbb17e1e07).
+[announcement](https://medium.com/continuous-delivery-scale/announcing-the-new-spinnaker-observability-plugin-d7fbb17e1e07).
 
 
 ## Configuring the Spinnaker Observability Plugin

--- a/content/en/docs/setup/productionize/scaling/horizontal-scaling.md
+++ b/content/en/docs/setup/productionize/scaling/horizontal-scaling.md
@@ -50,7 +50,7 @@ forwarding and waiting for the status of various tasks requested in a pipeline.
 Central to Orca's orchestration is a message queue, written into Redis and
 shared among all Orca nodes. This is explained in more detail [in this post on
 monitoring
-Spinnaker](https://blog.spinnaker.io/monitoring-spinnaker-part-1-4847f42a3abd)
+Spinnaker](https://medium.com/continuous-delivery-scale/monitoring-spinnaker-part-1-4847f42a3abd)
 for the curious.
 
 If you see slowdowns in some of Spinnaker's operations, such as...

--- a/hugo.toml
+++ b/hugo.toml
@@ -219,7 +219,7 @@ enable = false
 [[menu.main]]
   name = "Blog"
   weight = 4
-  url = "https://blog.spinnaker.io/"
+  url = "https://medium.com/continuous-delivery-scale/"
 
 [[menu.main]]
   name = "Docs"
@@ -282,7 +282,7 @@ enable = false
 #
 # [[menu.main]]
 #   name = "Blog"
-#   url = "https://blog.spinnaker.io/"
+#   url = "https://medium.com/continuous-delivery-scale/"
 #   weight = 4
 #
 # [permalinks]


### PR DESCRIPTION
Discussing with linux foundation options, but this is to get links working again since it appears our previous medium hosted page no longer works without a $5/month fee.