### PR TITLE
docs(orca): document reducing execution context size

### DIFF
--- a/content/en/docs/guides/runbooks/orca-reduce-execution-context-size.md
+++ b/content/en/docs/guides/runbooks/orca-reduce-execution-context-size.md
@@ -1,0 +1,128 @@
+---
+title: "Orca: Reducing Execution Context Size"
+linkTitle: "Orca: Execution Context Size"
+weight: 2
+description: "Some Orca tasks copy large objects such as manifests and artifacts into a stage's outputs, which are then propagated for the rest of the execution. You can configure Orca to exclude those keys and keep executions considerably smaller."
+---
+
+## Overview
+
+Every stage in an Orca execution has a `context` and an `outputs` map:
+
+* `context` is scoped to the stage. It holds whatever the stage's tasks need in order to do
+  their own work.
+* `outputs` is promoted to the execution and made visible to downstream stages, so anything a
+  task writes there is stored with the execution and travels with it for the remainder of the
+  pipeline.
+
+A handful of tasks write large objects (full Kubernetes manifests, artifact lists, raw job
+status payloads) into `outputs`. Because `outputs` is propagated, those objects are persisted
+repeatedly across the execution, which inflates the execution document in Orca's database, the
+payloads Deck fetches when rendering an execution, and Orca's memory footprint while the
+pipeline runs.
+
+Since Spinnaker 1.36.0 ([orca#4781](https://github.com/spinnaker/orca/pull/4781)) you can
+configure a set of keys to exclude from `outputs` for a specific set of tasks. The keys are
+still written to the stage's own `context`, so the stage keeps working as before — they are
+simply not promoted to the execution.
+
+{{% alert color="warning" title="Important" %}}
+Because the excluded keys are no longer present in `outputs`, they cannot be referenced from
+downstream stages via SpEL (for example `${#stage('Deploy')['outputs']['manifests']}`).
+Check your pipelines for expressions that read the keys you plan to exclude before rolling
+this out.
+{{% /alert %}}
+
+## Supported tasks
+
+Four tasks support exclusion today. The exact key names differ per task, and they are matched
+literally — note that `PromoteManifestKatoOutputsTask` stores its keys with an `outputs.`
+prefix, which is part of the key name and must be included in your configuration.
+
+| Task | Config prefix | Keys you can exclude |
+| ---- | ------------- | -------------------- |
+| `PromoteManifestKatoOutputsTask` | `tasks.clouddriver.promoteManifestKatoOutputsTask` | `outputs.manifests`, `outputs.manifestNamesByNamespace`, `outputs.boundArtifacts`, `outputs.createdArtifacts`, `artifacts` |
+| `WaitOnJobCompletion` | `tasks.clouddriver.waitOnJobCompletionTask` | `jobStatus`, `completionDetails`, `propertyFileContents` |
+| `ResolveDeploySourceManifestTask` | `tasks.clouddriver.resolveDeploySourceManifestTask` | `manifests`, `requiredArtifacts`, `optionalArtifacts` |
+| `BindProducedArtifactsTask` | `tasks.core.bindProducedArtifactsTask` | `artifacts`, `resolvedExpectedArtifacts` |
+
+The default for every `excludeKeysFromOutputs` property is an empty set, so this feature is
+off until you configure it.
+
+## Configuration
+
+Add the following to `orca-local.yml`:
+
+```yaml
+tasks:
+  clouddriver:
+    promoteManifestKatoOutputsTask:
+      excludeKeysFromOutputs:
+        - outputs.createdArtifacts
+        - outputs.manifests
+        - outputs.boundArtifacts
+    waitOnJobCompletionTask:
+      excludeKeysFromOutputs:
+        - jobStatus
+        - completionDetails
+    resolveDeploySourceManifestTask:
+      excludeKeysFromOutputs:
+        - manifests
+        - requiredArtifacts
+        - optionalArtifacts
+  core:
+    bindProducedArtifactsTask:
+      excludeKeysFromOutputs:
+        - artifacts
+```
+
+Each of these tasks logs the keys it was told to filter at startup and the keys that survived
+filtering on each execution, so you can confirm the configuration was picked up:
+
+```
+output keys to filter: [outputs.manifests, outputs.boundArtifacts, outputs.createdArtifacts]
+context outputs will only contain: [outputs.manifestNamesByNamespace, artifacts] keys
+```
+
+## Before and after
+
+The following comparison comes from running the same simple pipeline twice — once with the
+default configuration and once with the configuration above — and exporting the resulting
+execution JSON from `/pipelines/{executionId}` in Orca.
+
+| Measurement | Default configuration | Keys excluded | Reduction |
+| ----------- | --------------------- | ------------- | --------- |
+| Total lines | 4458 | 3291 | ~26% |
+| Size on local disk | 147 KB | 104 KB | ~29% |
+
+The gain scales with how much of your context is made up of the excluded objects. A pipeline
+that deploys many manifests or binds many artifacts, or one with a long chain of stages that
+each re-propagate the same `outputs`, will see a larger reduction than the simple pipeline
+measured above. Conversely, a pipeline that does not run any of the four supported tasks sees
+no change at all.
+
+To reproduce the measurement on your own pipeline:
+
+```bash
+# Fetch the execution as stored by Orca and measure it.
+curl -s "$ORCA_URL/pipelines/$EXECUTION_ID" | jq . > execution.json
+wc -l execution.json
+du -h execution.json
+```
+
+Run this once before applying the configuration and once after, using the same pipeline and
+the same inputs.
+
+## Rollout guidance
+
+1. Start with the keys that are largest and least likely to be referenced. `outputs.manifests`
+   and `outputs.createdArtifacts` from `PromoteManifestKatoOutputsTask` are usually the biggest
+   win for Kubernetes deployments; `jobStatus` and `completionDetails` are the biggest win for
+   pipelines that run jobs.
+2. Search your pipelines for SpEL expressions referencing those keys, and check any custom
+   stages or plugins that read from a previous stage's `outputs`.
+3. Roll out to a non-production Spinnaker first and run representative pipelines end to end.
+   Excluding a key that a downstream stage depends on surfaces as an expression evaluation
+   failure or a missing value in that stage, not as an error in the stage that produced it.
+4. Keep `outputs.manifestNamesByNamespace` unless you are certain nothing consumes it — Deck
+   and several downstream Kubernetes stages use it to locate deployed resources.

--- a/content/en/docs/guides/runbooks/orca-reduce-execution-size-stage-outputs.md
+++ b/content/en/docs/guides/runbooks/orca-reduce-execution-size-stage-outputs.md
@@ -1,6 +1,6 @@
 ---
 title: "Orca: Reducing Execution Size by Excluding Keys from Stage Outputs"
-linkTitle: "Orca: Excluding Stage Outputs"
+linkTitle: "Orca: Excluding Keys from Stage Outputs"
 weight: 2
 description: "Some Orca tasks copy large objects such as manifests and artifacts into a stage's outputs, which are then propagated for the rest of the execution. You can configure Orca to exclude those keys and keep executions considerably smaller."
 ---

--- a/content/en/docs/guides/runbooks/orca-reduce-execution-size-stage-outputs.md
+++ b/content/en/docs/guides/runbooks/orca-reduce-execution-size-stage-outputs.md
@@ -1,6 +1,6 @@
 ---
-title: "Orca: Reducing Execution Context Size"
-linkTitle: "Orca: Execution Context Size"
+title: "Orca: Reducing Execution Size by Excluding Keys from Stage Outputs"
+linkTitle: "Orca: Excluding Stage Outputs"
 weight: 2
 description: "Some Orca tasks copy large objects such as manifests and artifacts into a stage's outputs, which are then propagated for the rest of the execution. You can configure Orca to exclude those keys and keep executions considerably smaller."
 ---


### PR DESCRIPTION
Adds a runbook documenting the `excludeKeysFromOutputs` configuration introduced in spinnaker/orca#4781 (Spinnaker 1.36.0).

The feature is currently only described in the [1.36.0 changelog](https://spinnaker.io/changelogs/1.36.0-changelog/), which is easy to miss and doesn't explain the trade-offs. This gives it a permanent home under Runbooks, next to the other optional-Orca-feature pages (QoS, API rate limiting).

### What the page covers

- How the feature works: keys are dropped from a stage's `outputs` (which is promoted to the execution and visible downstream) but still written to the stage's own `context`, so the producing stage is unaffected.
- All four supported tasks with their **full** key lists, read from the task sources rather than the changelog snippet. This adds keys the changelog omits: `outputs.manifestNamesByNamespace` and `artifacts` (`PromoteManifestKatoOutputsTask`), `propertyFileContents` (`WaitOnJobCompletion`), and `resolvedExpectedArtifacts` (`BindProducedArtifactsTask`).
- That `PromoteManifestKatoOutputsTask` keys must carry the literal `outputs.` prefix, since `Task#filterContextOutputs` does an exact `contains` match on the key name. This is the easiest thing to get wrong.
- A warning that excluded keys can no longer be referenced from downstream SpEL.
- A before/after measurement of the same simple pipeline: ~26% fewer lines and ~29% smaller on disk, plus a recipe to reproduce the measurement on your own pipelines.
- Rollout guidance, including keeping `outputs.manifestNamesByNamespace` unless you're sure nothing consumes it.

Configuration is shown as plain `orca-local.yml` only, with no Halyard or operator variants, to stay consistent with the direction the docs are moving.

### Verification

`hugo --gc` builds clean (781 pages, no new warnings). Confirmed on the rendered HTML that the alert shortcode and both tables render, and that the SpEL example survives Goldmark intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
